### PR TITLE
Dashboard yol haritası ve izole restore rehberi

### DIFF
--- a/DASHBOARD-ROADMAP.en.md
+++ b/DASHBOARD-ROADMAP.en.md
@@ -1,0 +1,57 @@
+# Self-host Dashboard Roadmap
+
+[Turkce](./DASHBOARD-ROADMAP.md)
+
+The self-hosted panel is the real open-source Supabase Studio application. The
+main difference from the Cloud dashboard is not styling but its data source.
+Status, Compute, GitHub, Last Migration, Last Backup, request charts,
+infrastructure topology, project creation, and billing are populated by
+Supabase Platform control-plane APIs that are not included in the open-source
+Docker stack.
+
+## Available today
+
+- Table and SQL editors
+- Auth users and configuration
+- Storage bucket/object operations
+- Realtime inspector
+- Security Advisor
+- API keys and JWT/JWKS
+- Edge Function listing and invocation
+- Service logs when Logflare/Vector is enabled
+
+## Can be added with a management API
+
+- service health and restart counts
+- deployed commit and image versions
+- last migration and verified backup timestamp
+- request, error, and success-rate metrics
+- database size, connections, and Storage usage
+- Function secret CRUD and controlled restart
+- backup creation and restore-drill history
+- Function deploy/restart/log operations
+
+## Requires a separate control-plane product
+
+- creating isolated projects/stacks from one panel
+- per-project domains, secrets, volumes, and quotas
+- organizations, teams, and project switching
+- preview branch environments
+- managed compute, HA, PITR, and billing
+
+The presence of a Cloud page in the Studio source is not backend support. Those
+queries are gated by `IS_PLATFORM` and call Platform APIs that are absent from
+the open-source stack.
+
+## Delivery order
+
+1. **Operations dashboard:** health, commit, migration, backup, and Logflare
+   metric cards.
+2. **Panel operations:** Function secrets/deploy/logs and backup/restore jobs.
+3. **Project factory:** isolated stacks through platform adapters, including
+   but not limited to Coolify.
+4. **Advanced platform:** teams, preview environments, HA/PITR, quotas, and
+   optional billing.
+
+A card is not complete until its backend source, authorization boundary,
+loading/error state, tests, audit evidence, and rollback behavior are defined.

--- a/DASHBOARD-ROADMAP.md
+++ b/DASHBOARD-ROADMAP.md
@@ -1,0 +1,55 @@
+# Self-host Dashboard Yol Haritasi
+
+[English](./DASHBOARD-ROADMAP.en.md)
+
+Self-host panel, Supabase'in gercek acik kaynak Studio uygulamasidir. Cloud
+dashboard ile ana fark tasarim degil, veri kaynagidir: Status, Compute, GitHub,
+Last Migration, Last Backup, request grafikleri, altyapi haritasi, proje olusturma
+ve billing kartlari Supabase Platform control plane API'lerinden beslenir. Bu
+API'ler acik kaynak Docker stackinin parcasi degildir.
+
+## Bugun calisanlar
+
+- Table ve SQL Editor
+- Auth kullanicilari ve ayarlari
+- Storage bucket/obje islemleri
+- Realtime inspector
+- Security Advisor
+- API keys ve JWT/JWKS
+- Edge Functions listeleme/cagirma
+- Logflare/Vector etkinse servis loglari
+
+## Kendi yonetim API'mizle eklenebilir
+
+- servis sagligi ve restart sayisi
+- deploy commit/image surumleri
+- son migration ve dogrulanmis backup zamani
+- request, error ve success-rate metrikleri
+- database boyutu, connection ve Storage kullanimi
+- Function secret CRUD ve kontrollu restart
+- backup olusturma ve restore tatbikati gecmisi
+- Functions deploy/restart/log islemleri
+
+## Ayri control-plane urunu gerektirir
+
+- tek panelden yeni izole proje/stack olusturma
+- proje basina domain, secret, volume ve kaynak kotasi
+- organization/team ve proje degistirici
+- preview branch ortamlari
+- managed compute, HA, PITR ve billing
+
+Studio dosyalarinda Cloud sayfasinin bulunmasi yeterli degildir. Upstream kodda
+bu sorgular `IS_PLATFORM` ile sinirlanir ve acik kaynak stackte bulunmayan
+Platform API'lerini cagirir.
+
+## Gelistirme sirasi
+
+1. **Operasyon dashboardu:** health, commit, migration, backup ve Logflare
+   metrik kartlari.
+2. **Panel islemleri:** Functions secrets/deploy/log ve backup/restore jobs.
+3. **Proje fabrikasi:** Coolify dahil farkli deployment adapterlariyla izole
+   stack olusturma.
+4. **Gelismis platform:** teams, preview environments, HA/PITR ve kota/billing.
+
+Her kart icin backend kaynagi, yetki siniri, loading/error durumu, test, audit
+kaydi ve rollback davranisi tanimlanmadan ozellik tamamlandi sayilmaz.

--- a/README.en.md
+++ b/README.en.md
@@ -104,6 +104,8 @@ Generate fresh keys, use HTTPS, expose only the intended gateway, restrict datab
 - [Deployment](./DEPLOYMENT.md)
 - [Coolify](./COOLIFY.md)
 - [Edge Functions secret management](./FUNCTION-SECRETS.en.md)
+- [Dashboard and control-plane roadmap](./DASHBOARD-ROADMAP.en.md)
+- [Isolated backup restore drill](./RESTORE-DRILL.en.md)
 - [Configuration reference](./CONFIG.md)
 - [Operations, backup, restore, and rollback](./OPERATIONS.md)
 - [Migration](./MIGRATION.md)

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Yönetim kuralları: [GOVERNANCE.md](./GOVERNANCE.md) · [UPSTREAM-CONTRIBUTIONS
 - [Kurulum seçenekleri](./DEPLOYMENT.md)
 - [Coolify ayarları](./COOLIFY.md)
 - [Edge Functions secret yonetimi](./FUNCTION-SECRETS.md)
+- [Dashboard ve control-plane yol haritasi](./DASHBOARD-ROADMAP.md)
+- [Izole backup restore tatbikati](./RESTORE-DRILL.md)
 - [Ortam değişkenleri](./CONFIG.md)
 - [Yedek, güncelleme ve geri dönüş](./OPERATIONS.md)
 - [Supabase Cloud'dan taşıma](./MIGRATION.md)

--- a/RESTORE-DRILL.en.md
+++ b/RESTORE-DRILL.en.md
@@ -1,0 +1,33 @@
+# Isolated Backup Restore Drill
+
+[Turkce](./RESTORE-DRILL.md)
+
+Run restore validation in a temporary PostgreSQL container without attaching it
+to the production database or volumes.
+
+## Verified rules
+
+1. Verify checksums before restore.
+2. Use the same pinned `supabase/postgres` image version as the backup source.
+3. Do not rely only on `pg_isready`. Wait for `PostgreSQL init process complete;
+   ready for start up.` in the image log.
+4. Restore as the image's real superuser, `supabase_admin`.
+5. Create a temporary maintenance database, drop the initialized target
+   `postgres` database, and recreate it from `template0`.
+6. Filter only `CREATE ROLE` statements for roles already supplied by the target
+   image. Preserve missing roles and all later grants/attributes.
+7. Use `ON_ERROR_STOP=1` and keep restore logs private.
+8. Compare persistent schema/table, Auth user, and Storage bucket counts with
+   read-only source queries.
+9. Extract Storage/Functions/config archives into a temporary directory and
+   verify their contents.
+10. Remove temporary SQL, logs, container, directory, and volume.
+
+## Common restore failures
+
+- `role already exists`: the Supabase image pre-creates system roles.
+- `only superusers can modify it`: use `supabase_admin`, not `postgres`.
+- `schema auth already exists`: restore into a clean `template0` database after
+  image initialization completes.
+
+A backup is not considered verified until this isolated drill passes.

--- a/RESTORE-DRILL.md
+++ b/RESTORE-DRILL.md
@@ -1,0 +1,32 @@
+# Izole Backup Restore Tatbikati
+
+[English](./RESTORE-DRILL.en.md)
+
+Restore testi production database veya volume'una baglanmadan gecici bir
+PostgreSQL containerinda yapilmalidir.
+
+## Dogrulanmis kurallar
+
+1. Restore oncesi checksumlari dogrula.
+2. Backup ile ayni pinned `supabase/postgres` image surumunu kullan.
+3. Yalniz `pg_isready` bekleme. Image logunda `PostgreSQL init process complete;
+   ready for start up.` satirini bekle.
+4. Image'in gercek superuser rolu `supabase_admin` ile restore et.
+5. Gecici maintenance database olustur; initialize edilmis hedef `postgres`
+   database'i silip `template0` ile temiz olustur.
+6. Hedef image'de bulunan rollerin yalniz `CREATE ROLE` satirlarini gecici dump
+   akisindan filtrele. Eksik rolleri ve sonraki grant/attribute satirlarini koru.
+7. `ON_ERROR_STOP=1` kullan ve restore logunu gizli tut.
+8. Kalici schema/table, Auth user ve Storage bucket sayilarini kaynakla salt-okunur
+   karsilastir.
+9. Storage/Functions/config arsivlerini gecici dizine acip butunlugunu dogrula.
+10. Gecici SQL, log, container, dizin ve volume'u sil.
+
+## Sik restore hatalari
+
+- `role already exists`: Supabase image sistem rollerini onceden olusturur.
+- `only superusers can modify it`: `postgres` yerine `supabase_admin` gerekir.
+- `schema auth already exists`: hedef database image tarafindan initialize
+  edilmistir; temiz `template0` database'e restore gerekir.
+
+Production restore'dan once bu tatbikat gecmeden backup "dogrulanmis" sayilmaz.


### PR DESCRIPTION
## Türkçe
- Cloud ve self-host dashboard farkının gerçek nedenini açıklar
- Mevcut Studio özellikleri, yönetim API'siyle eklenebilecek kartlar ve ayrı control-plane kapsamını ayırır
- Coolify bağımlılığını azaltan dört aşamalı geliştirme sırasını yayınlar
- Supabase PostgreSQL için doğrulanmış izole restore prosedürünü ve yaygın hataları belgeler

## English
Publishes the dashboard/control-plane roadmap and the verified isolated backup restore procedure in English.

No private hostname, deployment id, credential, backup path, or production data is included.