### PR TITLE
📊 Salt okunur operasyon Management API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,15 @@ LOGFLARE_PUBLIC_ACCESS_TOKEN=your-super-secret-and-long-logflare-key-public
 # (Must be at least 32 characters; generate with openssl rand -base64 24)
 LOGFLARE_PRIVATE_ACCESS_TOKEN=your-super-secret-and-long-logflare-key-private
 
+# Internal operational management API. Never expose this token or service
+# directly to browsers or the public network.
+# Generate with: openssl rand -base64 48
+MANAGEMENT_API_TOKEN=your-super-secret-and-long-management-api-token
+DEPLOYED_COMMIT=unknown
+# Enable these probes only when the optional logging services are running.
+MANAGEMENT_ENABLE_ANALYTICS=false
+MANAGEMENT_ENABLE_VECTOR=false
+
 # Access key ID (username-like) for accessing the S3 protocol endpoint in Storage.
 # (Generate with: openssl rand -hex 16)
 S3_PROTOCOL_ACCESS_KEY_ID=625729a08b95bf1b7ff351a663f3a23c

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,6 +20,10 @@ jobs:
           find . -type f -name '*.sh' -print0 | xargs -0 -n1 bash -n
       - name: Test function secret management
         run: bash tests/test-function-secrets.sh
+      - name: Test management API
+        run: node --test management-api/server.test.mjs
+      - name: Test management status publisher
+        run: sh tests/test-management-status-publisher.sh
       - name: Check local Markdown links
         uses: lycheeverse/lychee-action@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 volumes/db/data
 volumes/storage
+volumes/management-status/*.json
 .env
 .coolify-env.generated
 test.http

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Added permanent Docker network aliases required by Studio, Realtime, and Edge Runtime under Coolify.
 - Added verified file-based Edge Functions secret management with a Coolify-compatible startup fallback.
 - Fixed Compose project discovery in the container log smoke test and documented Vector IPv6 healthcheck diagnostics.
+- Added an internal read-only operational Management API with bearer auth,
+  rate limiting, service probes, and sanitized backup/migration status files.
 
 All notable changes to the Supabase self-hosted Docker configuration.
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -77,6 +77,21 @@ The image tags below are pinned in `docker-compose.yml` at the time of this docu
 
 ## Studio (Dashboard)
 
+### Community operational Management API
+
+The base Compose file also starts an internal read-only `management-api`
+service. It is not routed through Kong and has no host port.
+
+| Variable | Type | Scope | Purpose |
+|---|---|---|---|
+| `MANAGEMENT_API_TOKEN` | secret string | Self-hosted | Required bearer token for `/v1/*`; never expose it to browser code. |
+| `DEPLOYED_COMMIT` | Git SHA or `unknown` | Self-hosted | Optional sanitized source commit displayed by operational clients. |
+| `MANAGEMENT_ENABLE_ANALYTICS` | boolean | Self-hosted | Probe optional Analytics only when that service is running. Default: `false`. |
+| `MANAGEMENT_ENABLE_VECTOR` | boolean | Self-hosted | Probe optional Vector only when that service is running. Default: `false`. |
+
+The service reads sanitized status JSON from `volumes/management-status`.
+See [MANAGEMENT-API.en.md](./MANAGEMENT-API.en.md).
+
 > Studio is a Next.js (Pages Router) app. `NEXT_PUBLIC_*` variables are inlined into the client bundle at build time and are visible in the browser - never store secrets in them.
 
 ### Core (database, API gateway, public URL)

--- a/DASHBOARD-ROADMAP.en.md
+++ b/DASHBOARD-ROADMAP.en.md
@@ -22,6 +22,11 @@ Docker stack.
 
 ## Can be added with a management API
 
+The first read-only backend stage is present as the `management-api` service.
+It provides service health, a sanitized deployment commit, and operator-verified
+backup/migration status. Studio project-home cards are not connected to this
+API yet; that panel integration is a separate stage.
+
 - service health and restart counts
 - deployed commit and image versions
 - last migration and verified backup timestamp

--- a/DASHBOARD-ROADMAP.md
+++ b/DASHBOARD-ROADMAP.md
@@ -21,6 +21,11 @@ API'ler acik kaynak Docker stackinin parcasi degildir.
 
 ## Kendi yonetim API'mizle eklenebilir
 
+Ilk salt okunur backend asamasi repository'de `management-api` servisi olarak
+bulunur. Servis sagligi, sanitize deploy commit'i ve operator tarafindan
+dogrulanmis backup/migration durumlarini saglar. Studio ana sayfa kartlari henuz
+bu API'ye bagli degildir; panel entegrasyonu ayri bir asamadir.
+
 - servis sagligi ve restart sayisi
 - deploy commit/image surumleri
 - son migration ve dogrulanmis backup zamani

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,5 +1,10 @@
 # Deployment Guide
 
+The base stack includes an internal read-only operational Management API. Set a
+fresh `MANAGEMENT_API_TOKEN` before deployment. Do not publish port `8080`, add
+the service to Kong, mount the Docker socket, or pass its bearer token to
+browser code. See [MANAGEMENT-API.en.md](./MANAGEMENT-API.en.md).
+
 Bu belge sifir sunucu, yeniden kurulum ve farkli Docker Compose platformlari icin ana kaynaktir.
 
 ## Mimari

--- a/MANAGEMENT-API.en.md
+++ b/MANAGEMENT-API.en.md
@@ -1,0 +1,43 @@
+# Read-only Operational Management API
+
+[Turkce](./MANAGEMENT-API.md)
+
+This repository includes an internal `management-api` service for reporting
+the operational state of one self-hosted Supabase stack. It is not the
+Supabase Cloud Platform API and does not provide organization/project creation,
+billing, branching, High Availability, or PITR.
+
+## Security boundary
+
+- Only `/health` is unauthenticated.
+- `/v1/overview` requires `Authorization: Bearer <MANAGEMENT_API_TOKEN>`.
+- The service has no host port and no Docker socket mount.
+- Its root filesystem is read-only, Linux capabilities are dropped, and
+  `no-new-privileges` is enabled.
+- The browser must never receive the token. A future Studio integration must
+  call it through a server-side proxy.
+- Database passwords, API keys, secrets, file paths, and raw errors are never
+  returned.
+
+## Overview contract
+
+`GET /v1/overview` returns sanitized fields for:
+
+- core service state as `healthy` or `unavailable`,
+- a valid deployment commit and the Management API version,
+- the last operator-verified backup timestamp,
+- the last operator-applied migration identifier and timestamp.
+
+Analytics and Vector are optional. Set `MANAGEMENT_ENABLE_ANALYTICS=true` and
+`MANAGEMENT_ENABLE_VECTOR=true` only when the related logging services run.
+
+After the owning backup or migration job completes its own verification:
+
+```sh
+sh utils/publish-management-status.sh backup-verified
+sh utils/publish-management-status.sh migration-applied 20260101000000_example
+```
+
+These commands do not verify a backup, checksum, or migration. They atomically
+publish a previously verified result as sanitized JSON. Studio project-home
+cards are not connected to this API yet.

--- a/MANAGEMENT-API.md
+++ b/MANAGEMENT-API.md
@@ -1,0 +1,42 @@
+# Salt Okunur Operasyon Management API
+
+[English](./MANAGEMENT-API.en.md)
+
+Bu repository, tek bir self-hosted Supabase stackinin operasyon durumunu
+sunmak icin ic agda calisan bir `management-api` servisi icerir. Bu servis
+Supabase Cloud Platform API degildir; organization/proje olusturmaz, billing,
+branching, HA veya PITR saglamaz.
+
+## Guvenlik siniri
+
+- Yalniz `/health` endpointi kimlik dogrulamasizdir.
+- `/v1/overview`, `Authorization: Bearer <MANAGEMENT_API_TOKEN>` ister.
+- Servisin host portu ve Docker socket mount'u yoktur.
+- Root filesystem salt okunur, Linux capability'leri kapali ve
+  `no-new-privileges` etkindir.
+- Browser tokeni alamaz. Studio entegrasyonu yapildiginda istek server-side
+  proxy uzerinden gitmelidir.
+- Database parolasi, API key, secret, dosya yolu ve ham hata donmez.
+
+## Overview sozlesmesi
+
+`GET /v1/overview` su sanitize alanlari dondurur:
+
+- cekirdek servislerin `healthy` veya `unavailable` durumu,
+- gecerliyse deploy commit'i ve Management API surumu,
+- operator tarafindan dogrulanmis son backup zamani,
+- operator tarafindan uygulanmis son migration kimligi ve zamani.
+
+Analytics ve Vector opsiyoneldir. Yalniz ilgili logs servisleri calisiyorsa
+`MANAGEMENT_ENABLE_ANALYTICS=true` ve `MANAGEMENT_ENABLE_VECTOR=true` yap.
+
+Backup veya migration islemi basariyla kendi dogrulamasini tamamladiktan sonra:
+
+```sh
+sh utils/publish-management-status.sh backup-verified
+sh utils/publish-management-status.sh migration-applied 20260101000000_example
+```
+
+Bu komutlar backup, checksum veya migration dogrulamasi yapmaz; yalniz daha once
+dogrulanmis sonucu atomik ve sanitize JSON olarak yayinlar. Studio ana sayfa
+kartlari henuz bu API'ye bagli degildir.

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -1,5 +1,11 @@
 # Operations Runbook
 
+After a backup job has verified its own checksum, or a migration job has
+completed successfully, it may publish sanitized dashboard state with
+`utils/publish-management-status.sh`. The publisher records an existing result;
+it does not perform backup or migration verification. See
+[MANAGEMENT-API.en.md](./MANAGEMENT-API.en.md).
+
 ## Gunluk Saglik Kontrolu
 
 ```bash

--- a/PLATFORM-CAPABILITIES.en.md
+++ b/PLATFORM-CAPABILITIES.en.md
@@ -29,6 +29,7 @@ This document separates repository presence from runtime proof. A service appear
 | postgres-meta | Included - default | Database metadata service used by Studio. |
 | Supavisor | Included - default | Connection pooler; published host ports require firewall/bind protection. |
 | Kong | Included - default | Main public application gateway; direct host ports must still be restricted. |
+| Community operational Management API | Included - default | Internal read-only service health and sanitized status data. It is not Supabase Platform API; Studio cards are not connected yet. |
 
 GitHub Actions validates base Compose and shell syntax. That is not production runtime proof.
 
@@ -50,7 +51,8 @@ The presence of optional files does not guarantee that every overlay combination
 
 - Cloud organization and multi-project control plane
 - Managed backup/PITR, High Availability, and automatic scaling
-- Supabase Platform Management API and managed branching
+- Supabase Platform Management API and managed branching. The community
+  operational API is not a Cloud control-plane equivalent.
 - Managed global multi-region Edge Functions
 - Cloud-only ETL, advanced analytics, and integrations without an independently deployed open-source equivalent
 

--- a/PLATFORM-CAPABILITIES.md
+++ b/PLATFORM-CAPABILITIES.md
@@ -17,6 +17,11 @@ Bu belge yalnız mevcut repository içeriğini ve doğrulanmış davranışı an
 
 ## Temel Stack
 
+Topluluk operasyon `management-api` servisi temel Compose icinde bulunur. Ic
+agda salt okunur servis sagligi ve sanitize backup/migration durumunu sunar.
+Supabase Platform Management API degildir ve Studio kartlari henuz bu servise
+bagli degildir. Ayrintilar: [MANAGEMENT-API.md](./MANAGEMENT-API.md).
+
 | Yetenek | Durum | Kanıt ve sınır |
 |---|---|---|
 | PostgreSQL | Dahil - varsayılan | `docker-compose.yml` içindeki `db` servisi. Backup, bakım ve HA kullanıcı sorumluluğudur. |
@@ -50,6 +55,10 @@ Temel Compose ve shell kontrolleri GitHub Actions içinde çalışır. Bu doğru
 Opsiyonel bir dosyanın repository içinde bulunması, bütün kombinasyonların aynı anda desteklendiği anlamına gelmez. Her kombinasyon ayrı Compose config ve smoke testi gerektirir.
 
 ## Supabase Cloud ile Farklar
+
+Asagidaki Supabase Platform Management API siniri degismemistir. Repository'deki
+topluluk operasyon API'si Cloud organization/proje kontrol duzleminin esdegeri
+degildir.
 
 | Cloud yeteneği | Self-host durumu |
 |---|---|

--- a/README.en.md
+++ b/README.en.md
@@ -105,6 +105,7 @@ Generate fresh keys, use HTTPS, expose only the intended gateway, restrict datab
 - [Coolify](./COOLIFY.md)
 - [Edge Functions secret management](./FUNCTION-SECRETS.en.md)
 - [Dashboard and control-plane roadmap](./DASHBOARD-ROADMAP.en.md)
+- [Read-only operational Management API](./MANAGEMENT-API.en.md)
 - [Isolated backup restore drill](./RESTORE-DRILL.en.md)
 - [Configuration reference](./CONFIG.md)
 - [Operations, backup, restore, and rollback](./OPERATIONS.md)

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Arama, yapay zekâ ve dokümantasyon araçları için proje kaynak haritası [ll
 - [Coolify ayarları](./COOLIFY.md)
 - [Edge Functions secret yonetimi](./FUNCTION-SECRETS.md)
 - [Dashboard ve control-plane yol haritasi](./DASHBOARD-ROADMAP.md)
+- [Salt okunur operasyon Management API](./MANAGEMENT-API.md)
 - [Izole backup restore tatbikati](./RESTORE-DRILL.md)
 - [Ortam değişkenleri](./CONFIG.md)
 - [Yedek, güncelleme ve geri dönüş](./OPERATIONS.md)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,35 @@
 
 services:
 
+  management-api:
+    build:
+      context: ./management-api
+    restart: unless-stopped
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "node -e \"fetch('http://127.0.0.1:8080/health').then((r) => {if (!r.ok) throw new Error(r.status)})\""
+        ]
+      timeout: 5s
+      interval: 10s
+      retries: 3
+      start_period: 10s
+    environment:
+      MANAGEMENT_API_TOKEN: ${MANAGEMENT_API_TOKEN}
+      DEPLOYED_COMMIT: ${DEPLOYED_COMMIT:-unknown}
+      BACKUP_STATUS_FILE: /run/management/backup-status.json
+      MIGRATION_STATUS_FILE: /run/management/migration-status.json
+      MANAGEMENT_ENABLE_ANALYTICS: ${MANAGEMENT_ENABLE_ANALYTICS:-false}
+      MANAGEMENT_ENABLE_VECTOR: ${MANAGEMENT_ENABLE_VECTOR:-false}
+    volumes:
+      - ./volumes/management-status:/run/management:ro,z
+
   studio:
     image: supabase/studio:2026.07.07-sha-a6a04f2
     restart: unless-stopped

--- a/management-api/Dockerfile
+++ b/management-api/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:22-alpine
+
+WORKDIR /app
+COPY package.json server.mjs ./
+
+ENV NODE_ENV=production
+ENV PORT=8080
+
+USER node
+EXPOSE 8080
+CMD ["node", "server.mjs"]

--- a/management-api/package.json
+++ b/management-api/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "supabase-turkiye-management-api",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "start": "node server.mjs",
+    "test": "node --test"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/management-api/server.mjs
+++ b/management-api/server.mjs
@@ -1,0 +1,178 @@
+import { timingSafeEqual } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { connect } from 'node:net'
+import { pathToFileURL } from 'node:url'
+
+const VERSION = '0.2.0'
+const DEFAULT_LIMIT = 60
+const DEFAULT_WINDOW_MS = 60_000
+
+export function isAuthorized(header, expectedToken) {
+  if (!expectedToken || !header?.startsWith('Bearer ')) return false
+  const supplied = Buffer.from(header.slice(7))
+  const expected = Buffer.from(expectedToken)
+  return supplied.length === expected.length && timingSafeEqual(supplied, expected)
+}
+
+export function createRateLimiter({ limit = DEFAULT_LIMIT, windowMs = DEFAULT_WINDOW_MS } = {}) {
+  const clients = new Map()
+  return (client, now = Date.now()) => {
+    const current = clients.get(client)
+    if (!current || now - current.startedAt >= windowMs) {
+      clients.set(client, { count: 1, startedAt: now })
+      return true
+    }
+    current.count += 1
+    return current.count <= limit
+  }
+}
+
+export function checkTcp({ host, port, timeoutMs = 800 }) {
+  return new Promise((resolve) => {
+    const socket = connect({ host, port })
+    const finish = (result) => {
+      socket.destroy()
+      resolve(result)
+    }
+    socket.setTimeout(timeoutMs)
+    socket.once('connect', () => finish('healthy'))
+    socket.once('timeout', () => finish('unavailable'))
+    socket.once('error', () => finish('unavailable'))
+  })
+}
+
+function unavailableStatus() {
+  return { status: 'unavailable' }
+}
+
+export async function readBackupStatus(filePath) {
+  if (!filePath) return unavailableStatus()
+
+  try {
+    const value = JSON.parse(await readFile(filePath, 'utf8'))
+    if (value.status !== 'verified' || !Number.isFinite(Date.parse(value.lastVerifiedAt))) {
+      return unavailableStatus()
+    }
+    return { status: 'verified', lastVerifiedAt: new Date(value.lastVerifiedAt).toISOString() }
+  } catch {
+    return unavailableStatus()
+  }
+}
+
+export async function readMigrationStatus(filePath) {
+  if (!filePath) return unavailableStatus()
+
+  try {
+    const value = JSON.parse(await readFile(filePath, 'utf8'))
+    if (
+      value.status !== 'applied' ||
+      typeof value.lastApplied !== 'string' ||
+      !/^[A-Za-z0-9_.-]{1,128}$/.test(value.lastApplied) ||
+      !Number.isFinite(Date.parse(value.appliedAt))
+    ) {
+      return unavailableStatus()
+    }
+    return {
+      status: 'applied',
+      lastApplied: value.lastApplied,
+      appliedAt: new Date(value.appliedAt).toISOString(),
+    }
+  } catch {
+    return unavailableStatus()
+  }
+}
+
+export async function buildOverview({ probes, commit = 'unknown', backupStatusFile, migrationStatusFile }) {
+  const [entries, backup, migration] = await Promise.all([
+    Promise.all(
+      Object.entries(probes).map(async ([name, target]) => [name, await checkTcp(target)])
+    ),
+    readBackupStatus(backupStatusFile),
+    readMigrationStatus(migrationStatusFile),
+  ])
+  const services = Object.fromEntries(entries)
+  const status = Object.values(services).every((value) => value === 'healthy')
+    ? 'healthy'
+    : 'degraded'
+
+  return {
+    generatedAt: new Date().toISOString(),
+    status,
+    services,
+    deployment: {
+      commit: /^[0-9a-f]{7,40}$/i.test(commit) ? commit : 'unknown',
+      version: VERSION,
+    },
+    backup,
+    migration,
+  }
+}
+
+export function buildDefaultProbes(environment = process.env) {
+  const probes = {
+    database: { host: 'db', port: 5432 },
+    auth: { host: 'auth', port: 9999 },
+    rest: { host: 'rest', port: 3000 },
+    realtime: { host: 'realtime', port: 4000 },
+    storage: { host: 'storage', port: 5000 },
+    functions: { host: 'functions', port: 9000 },
+  }
+
+  if (environment.MANAGEMENT_ENABLE_ANALYTICS === 'true') {
+    probes.analytics = { host: 'analytics', port: 4000 }
+  }
+  if (environment.MANAGEMENT_ENABLE_VECTOR === 'true') {
+    probes.vector = { host: 'vector', port: 9001 }
+  }
+
+  return probes
+}
+
+export function createApp(options = {}) {
+  const token = options.token ?? process.env.MANAGEMENT_API_TOKEN ?? ''
+  const allowRequest = createRateLimiter(options.rateLimit)
+  const probes = options.probes ?? buildDefaultProbes()
+
+  return createServer(async (request, response) => {
+    response.setHeader('content-type', 'application/json; charset=utf-8')
+
+    if (request.url === '/health') {
+      response.end(JSON.stringify({ status: 'ok', version: VERSION }))
+      return
+    }
+
+    const client = request.socket.remoteAddress ?? 'unknown'
+    if (!allowRequest(client)) {
+      response.writeHead(429)
+      response.end(JSON.stringify({ error: 'rate_limited' }))
+      return
+    }
+
+    if (!isAuthorized(request.headers.authorization, token)) {
+      response.writeHead(401)
+      response.end(JSON.stringify({ error: 'unauthorized' }))
+      return
+    }
+
+    if (request.method === 'GET' && request.url === '/v1/overview') {
+      const overview = await buildOverview({
+        probes,
+        commit: process.env.DEPLOYED_COMMIT ?? 'unknown',
+        backupStatusFile: options.backupStatusFile ?? process.env.BACKUP_STATUS_FILE,
+        migrationStatusFile: options.migrationStatusFile ?? process.env.MIGRATION_STATUS_FILE,
+      })
+      response.end(JSON.stringify(overview))
+      return
+    }
+
+    response.writeHead(404)
+    response.end(JSON.stringify({ error: 'not_found' }))
+  })
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const port = Number(process.env.PORT ?? 8080)
+  const server = createApp()
+  server.listen(port, '0.0.0.0')
+}

--- a/management-api/server.test.mjs
+++ b/management-api/server.test.mjs
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict'
+import { once } from 'node:events'
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+
+import {
+  createApp,
+  createRateLimiter,
+  buildDefaultProbes,
+  isAuthorized,
+  readBackupStatus,
+  readMigrationStatus,
+} from './server.mjs'
+
+test('optional probes are enabled only by explicit flags', () => {
+  const core = buildDefaultProbes({})
+  assert.equal('analytics' in core, false)
+  assert.equal('vector' in core, false)
+
+  const logs = buildDefaultProbes({
+    MANAGEMENT_ENABLE_ANALYTICS: 'true',
+    MANAGEMENT_ENABLE_VECTOR: 'true',
+  })
+  assert.deepEqual(logs.analytics, { host: 'analytics', port: 4000 })
+  assert.deepEqual(logs.vector, { host: 'vector', port: 9001 })
+})
+
+test('authorization requires an exact bearer token', () => {
+  assert.equal(isAuthorized('Bearer expected', 'expected'), true)
+  assert.equal(isAuthorized('Bearer wrong', 'expected'), false)
+  assert.equal(isAuthorized(undefined, 'expected'), false)
+  assert.equal(isAuthorized('Bearer expected', ''), false)
+})
+
+test('rate limiter resets after its window', () => {
+  const allow = createRateLimiter({ limit: 2, windowMs: 100 })
+  assert.equal(allow('client', 0), true)
+  assert.equal(allow('client', 1), true)
+  assert.equal(allow('client', 2), false)
+  assert.equal(allow('client', 101), true)
+})
+
+test('status files accept only sanitized and valid schemas', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'management-api-'))
+  const backupFile = join(directory, 'backup.json')
+  const migrationFile = join(directory, 'migration.json')
+
+  await writeFile(
+    backupFile,
+    JSON.stringify({ status: 'verified', lastVerifiedAt: '2026-07-11T09:00:00Z', secret: 'ignored' })
+  )
+  await writeFile(
+    migrationFile,
+    JSON.stringify({ status: 'applied', lastApplied: '20260711090000_schema', appliedAt: '2026-07-11T09:01:00Z' })
+  )
+
+  assert.deepEqual(await readBackupStatus(backupFile), {
+    status: 'verified',
+    lastVerifiedAt: '2026-07-11T09:00:00.000Z',
+  })
+  assert.deepEqual(await readMigrationStatus(migrationFile), {
+    status: 'applied',
+    lastApplied: '20260711090000_schema',
+    appliedAt: '2026-07-11T09:01:00.000Z',
+  })
+})
+
+test('missing and malformed status files are unavailable without raw errors', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'management-api-'))
+  const malformedFile = join(directory, 'malformed.json')
+  await writeFile(malformedFile, '{not-json')
+
+  assert.deepEqual(await readBackupStatus(), { status: 'unavailable' })
+  assert.deepEqual(await readBackupStatus(malformedFile), { status: 'unavailable' })
+  assert.deepEqual(await readMigrationStatus(join(directory, 'missing.json')), {
+    status: 'unavailable',
+  })
+})
+
+test('health is public and overview is protected and sanitized', async (context) => {
+  const server = createApp({
+    token: 'test-token',
+    probes: { database: { host: '127.0.0.1', port: 1, timeoutMs: 10 } },
+    backupStatusFile: 'does-not-exist',
+    migrationStatusFile: 'does-not-exist',
+  })
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+  context.after(() => server.close())
+
+  const { port } = server.address()
+  const health = await fetch(`http://127.0.0.1:${port}/health`)
+  assert.equal(health.status, 200)
+
+  const denied = await fetch(`http://127.0.0.1:${port}/v1/overview`)
+  assert.equal(denied.status, 401)
+
+  const allowed = await fetch(`http://127.0.0.1:${port}/v1/overview`, {
+    headers: { authorization: 'Bearer test-token' },
+  })
+  assert.equal(allowed.status, 200)
+  const body = await allowed.json()
+  assert.equal(body.status, 'degraded')
+  assert.equal(body.services.database, 'unavailable')
+  assert.deepEqual(body.backup, { status: 'unavailable' })
+  assert.deepEqual(body.migration, { status: 'unavailable' })
+  assert.equal(JSON.stringify(body).includes('test-token'), false)
+})

--- a/tests/test-management-status-publisher.sh
+++ b/tests/test-management-status-publisher.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+set -eu
+
+root=$(mktemp -d)
+trap 'rm -rf "$root"' EXIT HUP INT TERM
+
+STATUS_DIR="$root" sh utils/publish-management-status.sh backup-verified
+grep -Eq '^\{"status":"verified","lastVerifiedAt":"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"\}$' \
+  "$root/backup-status.json"
+
+STATUS_DIR="$root" sh utils/publish-management-status.sh \
+  migration-applied 20260711100000_example
+grep -Eq '^\{"status":"applied","lastApplied":"20260711100000_example","appliedAt":"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"\}$' \
+  "$root/migration-status.json"
+
+if STATUS_DIR="$root" sh utils/publish-management-status.sh \
+  migration-applied 'unsafe/value'; then
+  echo 'Unsafe migration identifier was accepted.' >&2
+  exit 1
+fi
+
+test "$(wc -l < "$root/backup-status.json")" -eq 1
+test "$(wc -l < "$root/migration-status.json")" -eq 1
+
+echo 'Management status publisher tests passed.'

--- a/utils/publish-management-status.sh
+++ b/utils/publish-management-status.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env sh
+set -eu
+
+status_dir=${STATUS_DIR:-./volumes/management-status}
+command_name=${1:-}
+value=${2:-}
+
+usage() {
+  echo 'Usage: publish-management-status.sh backup-verified | migration-applied MIGRATION_ID' >&2
+  exit 2
+}
+
+write_atomic() {
+  target=$1
+  content=$2
+  mkdir -p "$status_dir"
+  umask 077
+  temporary=$(mktemp "$status_dir/.status.XXXXXX")
+  trap 'rm -f "$temporary"' EXIT HUP INT TERM
+  printf '%s\n' "$content" > "$temporary"
+  mv "$temporary" "$status_dir/$target"
+  trap - EXIT HUP INT TERM
+}
+
+timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+case "$command_name" in
+  backup-verified)
+    [ "$#" -eq 1 ] || usage
+    write_atomic backup-status.json \
+      "{\"status\":\"verified\",\"lastVerifiedAt\":\"$timestamp\"}"
+    ;;
+  migration-applied)
+    [ "$#" -eq 2 ] || usage
+    case "$value" in
+      ''|*[!A-Za-z0-9_.-]*)
+        echo 'Migration identifier contains unsupported characters.' >&2
+        exit 2
+        ;;
+    esac
+    [ "${#value}" -le 128 ] || {
+      echo 'Migration identifier exceeds 128 characters.' >&2
+      exit 2
+    }
+    write_atomic migration-status.json \
+      "{\"status\":\"applied\",\"lastApplied\":\"$value\",\"appliedAt\":\"$timestamp\"}"
+    ;;
+  *) usage ;;
+esac

--- a/volumes/management-status/README.md
+++ b/volumes/management-status/README.md
@@ -1,0 +1,37 @@
+# Management Status Files
+
+This directory is mounted read-only into the internal management API. Runtime
+JSON files are ignored by Git and must contain sanitized status only.
+
+`backup-status.json`:
+
+```json
+{
+  "status": "verified",
+  "lastVerifiedAt": "2026-01-01T00:00:00Z"
+}
+```
+
+`migration-status.json`:
+
+```json
+{
+  "status": "applied",
+  "lastApplied": "20260101000000_example",
+  "appliedAt": "2026-01-01T00:00:00Z"
+}
+```
+
+The backup job may publish `verified` only after its checksum verification has
+passed. Write to a temporary file in this directory and rename it atomically.
+Never include paths, database names, credentials, archive names or error text.
+
+Use the tested publisher only after the owning job has succeeded:
+
+```sh
+sh utils/publish-management-status.sh backup-verified
+sh utils/publish-management-status.sh migration-applied 20260101000000_example
+```
+
+These commands record an already verified outcome; they do not perform backup,
+checksum or migration verification themselves.


### PR DESCRIPTION
## Ozet / Summary

Tek self-hosted stack icin internal, salt okunur operasyon Management API ekler. Cloud control-plane veya Supabase Platform API esdegeri degildir; Studio kartlari henuz bagli degildir.

Adds an internal read-only operational Management API for one self-hosted stack. It is not a Cloud control-plane or Supabase Platform API equivalent; Studio cards are not connected yet.

## Sinif / Classification

- [x] community-only
- [ ] deployment-only
- [ ] upstream-candidate
- [x] security-sensitive

## Kanit / Evidence

- Private acceptance completed before sanitization: internal health and protected overview returned success, invalid bearer was rejected, and no host port or Docker socket was present.
- Public PR contains no private domain, resource ID, credential, runtime log, or deployment evidence.
- Core probes are default; optional Analytics/Vector probes require explicit flags.

## Dogrulama / Verification

- [ ] docker compose --env-file .env.example config -q (GitHub CI)
- [x] node --test management-api/server.test.mjs (6/6)
- [ ] Shell publisher tests (GitHub CI)
- [ ] Markdown links (GitHub CI)
- [x] Secret/private identifier scan
- [x] Turkish and English docs updated
- [x] Capability state distinguishes the community API from Supabase Platform API

## AI Assistance / Yapay Zeka Desteği

- [x] AI desteği kullanıldı; güvenlik sınırı, testler ve public sanitization insan sahibi adına CI ve diff kontrolleriyle sunuldu.

## Upstream

Community operational extension. It is not submitted upstream in this PR; any upstream candidate requires a separate minimal reproduction and approval.