### PR TITLE
Studio ve Function Secrets rollout kanıtlarını belgeye işle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Self-hosted Studio operations and secrets - 2026-07-12
+
+- Added Operations and Usage cards backed by self-hosted services.
+- Added Observability Lite through Query Performance and Dashboard Preferences.
+- Added persistent, redacted Function Secrets CRUD with Edge Runtime hot reload.
+- Documented the failed nested-mount rollout, rollback, isolated-volume fix, and
+  successful stable redeployment.
+
 ## Local distribution notes - 2026-07-11
 
 - Added reusable deployment, operations, migration, capability, and AI handoff documentation.

--- a/DASHBOARD-ROADMAP.en.md
+++ b/DASHBOARD-ROADMAP.en.md
@@ -60,3 +60,11 @@ the open-source stack.
 
 A card is not complete until its backend source, authorization boundary,
 loading/error state, tests, audit evidence, and rollback behavior are defined.
+
+## Current Delivery Status
+
+- Completed: Operations, Usage, Observability Lite, Dashboard Preferences, and
+  persistent Function Secrets CRUD.
+- Evidence-only: backup and migration status cards.
+- Remaining: backup/restore job execution, migration execution, and a separate
+  multi-project control plane.

--- a/DASHBOARD-ROADMAP.md
+++ b/DASHBOARD-ROADMAP.md
@@ -58,3 +58,11 @@ Platform API'lerini cagirir.
 
 Her kart icin backend kaynagi, yetki siniri, loading/error durumu, test, audit
 kaydi ve rollback davranisi tanimlanmadan ozellik tamamlandi sayilmaz.
+
+## Guncel Teslim Durumu
+
+- Tamamlandi: Operations, Usage, Observability Lite, Dashboard Preferences ve
+  kalici Function Secrets CRUD.
+- Yalniz kanit gosterir: backup ve migration durum kartlari.
+- Kalan: backup/restore job calistirma, migration uygulama ve ayri coklu proje
+  control plane.

--- a/FUNCTION-SECRETS.en.md
+++ b/FUNCTION-SECRETS.en.md
@@ -1,54 +1,36 @@
 # Edge Functions Secret Management
 
-The secret CRUD UI in Supabase Cloud belongs to its managed control plane. A
-self-hosted deployment supplies environment variables to Edge Runtime instead.
-This repository implements that model with a portable file and without storing
-secret values in Git.
+Self-hosted Studio manages Edge Function secrets through a versioned JSON store.
+Values are never revealed after saving; list responses contain only the name,
+update timestamp, and SHA-256 digest.
 
-## Usage
+## Runtime model
 
-The default file is `volumes/functions/.env`. It is stored with mode `0600` and
-is ignored by Git.
+- Studio path: `/app/function-secrets/.supabase/function-secrets.json`
+- Edge Runtime path: `/run/function-secrets/.supabase/function-secrets.json`
+- Persistence: the `function-secrets` named volume
+- New file mode: `0600`
+- Activation: hot-loaded for subsequent function requests; no restart required
 
-```bash
-printf '%s\n' "$VALUE" | bash utils/manage-function-secrets.sh set SECRET_NAME
-bash utils/manage-function-secrets.sh list
-bash utils/manage-function-secrets.sh unset SECRET_NAME
-docker compose up -d --force-recreate functions
-```
+Function sources remain read-only in Studio. The secret volume is isolated from
+the source bind mount, preserving values across Coolify release directories and
+avoiding nested-mount failures.
 
-`list` prints names only. Values are never written to command output. Multiline
-values are not supported.
+Reserved runtime names such as `SUPABASE_*`, `SB_*`, `DENO_*`, `JWT_SECRET`,
+and `VERIFY_JWT` cannot be managed. Invalid store updates retain the last valid
+snapshot, and logs never include secret values.
 
-## Coolify Note
+## Safe verification
 
-Platforms can normalize or omit Compose `env_file`, and Compose interpolation
-can change values containing `$`. The Functions service therefore does not use
-the secret file as `env_file`; it loads the raw mounted file safely at startup.
-Do not manually edit a platform-generated Compose file.
+1. Open **Edge Functions > Secrets** in Studio.
+2. Add a synthetic, non-sensitive secret.
+3. Confirm the list shows a digest instead of plaintext.
+4. Invoke a smoke function that returns only whether the variable exists.
+5. Update the secret and verify the next request without restarting the runtime.
+6. Delete it and confirm the next request no longer sees it.
+7. Redeploy and confirm the named volume preserves the list.
 
-Runtime shell variables inside Compose must be escaped as `$$line`. A single
-`$line` is expanded before the container starts and breaks the loader.
-
-The loader never overrides names already supplied by the service `environment`
-block. The management tool rejects reserved runtime names such as `JWT_SECRET`,
-`SUPABASE_URL`, and `SUPABASE_DB_URL`. Multiline input fails instead of being
-silently truncated.
-
-## Safe Verification
-
-Set a synthetic secret, recreate the Functions container, and check only its
-name in PID 1's environment without printing the value:
-
-```bash
-docker exec "$FUNCTIONS_CONTAINER" sh -c \
-  'tr "\000" "\n" < /proc/1/environ | grep -q "^SYNTHETIC_SECRET="'
-```
-
-`docker exec ... test -n "$SYNTHETIC_SECRET"` can produce a false negative. A
-new exec process does not inherit variables exported dynamically into PID 1 by
-the entrypoint. Remove the synthetic secret and recreate the container after
-the test.
-
-This is not a clone of Supabase Cloud's secret control plane. It is auditable,
-file-based secret management for self-hosted Edge Runtime.
+Never commit the store, copy it into an image, print it in deployment logs, or
+place it in an unencrypted backup. This is not a clone of the Supabase Cloud
+control plane; it is an auditable secret CRUD and runtime-loading layer for one
+self-hosted stack.

--- a/FUNCTION-SECRETS.md
+++ b/FUNCTION-SECRETS.md
@@ -1,53 +1,35 @@
 # Edge Functions Secret Yonetimi
 
-Supabase Cloud'daki secret CRUD ekrani managed control plane'e aittir. Self-host
-kurulumda desteklenen model, Edge Runtime'a environment variable saglamaktir.
-Bu repository bunu Git'e secret yazmadan tasinabilir bir dosya ile uygular.
+Self-host Studio, Edge Function secret degerlerini versioned JSON store uzerinden
+yonetebilir. Degerler kaydedildikten sonra tekrar gosterilmez; liste API'si
+yalniz ad, guncelleme zamani ve SHA-256 digest dondurur.
 
-## Kullanim
+## Calisma modeli
 
-Varsayilan dosya `volumes/functions/.env` olur, `0600` izniyle saklanir ve Git
-tarafindan izlenmez.
+- Studio path: `/app/function-secrets/.supabase/function-secrets.json`
+- Edge Runtime path: `/run/function-secrets/.supabase/function-secrets.json`
+- Kalicilik: `function-secrets` named volume
+- Yeni dosya modu: `0600`
+- Uygulama: sonraki function isteginde hot reload; container restart gerekmez
 
-```bash
-printf '%s\n' "$DEGER" | bash utils/manage-function-secrets.sh set SECRET_ADI
-bash utils/manage-function-secrets.sh list
-bash utils/manage-function-secrets.sh unset SECRET_ADI
-docker compose up -d --force-recreate functions
-```
+Function kaynaklari Studio'da salt okunur kalir. Secret volume kaynak bind
+mountundan ayridir; bu ayrim Coolify release dizini degisimlerinde kaliciligi
+korur ve nested mount sorununu onler.
 
-`list` yalniz adlari gosterir. Degerler komut ciktisina yazilmaz. Cok satirli
-degerler desteklenmez.
+`SUPABASE_*`, `SB_*`, `DENO_*`, `JWT_SECRET` ve `VERIFY_JWT` gibi runtime
+isimleri yonetilemez. Gecersiz store son gecerli snapshot'i bozmaz ve loglara
+secret degeri yazilmaz.
 
-## Coolify Notu
+## Guvenli dogrulama
 
-Bazi platformlar Compose `env_file` alanini farkli yorumlar veya kaldirir. Ayrica
-Compose, `$` iceren degerlerde interpolation uygulayabilir. Bu nedenle Functions
-servisi dosyayi `env_file` olarak tanimlamaz; raw mount uzerinden baslangicta
-guvenli bicimde yukler. Uretilen Compose dosyasini elle degistirmeyin.
+1. Studio'da **Edge Functions > Secrets** sayfasini acin.
+2. Sentetik ve hassas olmayan bir secret ekleyin.
+3. Listede plaintext yerine digest gorundugunu kontrol edin.
+4. Yalniz degiskenin varligini boolean olarak donduren smoke function cagirin.
+5. Secret'i guncelleyin; restart yapmadan sonraki istekte degisikligi dogrulayin.
+6. Secret'i silin ve sonraki istekte kaldirildigini dogrulayin.
+7. Redeploy sonrasi listenin named volume sayesinde korundugunu kontrol edin.
 
-Compose icindeki runtime shell degiskenleri `$$line` seklinde kacirilmalidir.
-Tek `$line`, Compose tarafindan container baslamadan genisletilir ve loader'i
-bozar.
-
-Loader, servis `environment` blogunda zaten bulunan isimleri ezmez. Yonetim
-araci `JWT_SECRET`, `SUPABASE_URL`, `SUPABASE_DB_URL` ve diger cekirdek runtime
-isimlerini reddeder. Multiline girdi hata verir; sessizce kisaltilmaz.
-
-## Guvenli Dogrulama
-
-Sentetik bir secret ekleyin, Functions container'ini yeniden olusturun ve degeri
-yazdirmadan yalniz PID 1 environment'inda adini kontrol edin:
-
-```bash
-docker exec "$FUNCTIONS_CONTAINER" sh -c \
-  'tr "\000" "\n" < /proc/1/environ | grep -q "^SYNTHETIC_SECRET="'
-```
-
-`docker exec ... test -n "$SYNTHETIC_SECRET"` yanlis negatif verebilir. Yeni
-exec sureci, entrypoint'in PID 1'e sonradan export ettigi degiskenleri miras
-almaz. Test bittiginde sentetik secret'i kaldirin ve container'i yeniden
-olusturun.
-
-Bu ozellik Supabase Cloud secret panelinin birebir kopyasi degildir; self-host
-Edge Runtime icin denetlenebilir dosya tabanli secret yonetimidir.
+Secret dosyasini Git'e, image'a, deployment loguna veya sifresiz backup'a
+eklemeyin. Bu ozellik Supabase Cloud control plane kopyasi degildir; tek
+self-host stack icin denetlenebilir secret CRUD ve runtime yukleme katmanidir.

--- a/PLATFORM-CAPABILITIES.en.md
+++ b/PLATFORM-CAPABILITIES.en.md
@@ -65,3 +65,16 @@ A capability is runtime-verified only when evidence records the commit SHA, sele
 Without that evidence, documentation may say **included**, **optional**, or **unverified**, but must not claim production validation.
 
 Documentation update rules: [DOCUMENTATION-MAINTENANCE.md](./DOCUMENTATION-MAINTENANCE.md).
+
+## Verified Community Studio Extensions
+
+| Capability | Verified boundary |
+|---|---|
+| Operations cards | Read-only service health and deployed commit from the internal Management API. |
+| Usage cards | Last-24-hour aggregation from self-hosted Logflare raw tables. |
+| Observability Lite | Query Performance only; cloud control-plane reports remain disabled. |
+| Dashboard Preferences | Local browser preferences with no platform API or billing dependency. |
+| Function Secrets | Redacted CRUD, persistent named volume, and Edge Runtime hot reload. |
+
+Backup and migration cards display only operator-published status evidence. The
+dashboard does not yet create backups, execute restores, or apply migrations.

--- a/PLATFORM-CAPABILITIES.md
+++ b/PLATFORM-CAPABILITIES.md
@@ -95,4 +95,18 @@ Bir capability ancak aşağıdaki kanıtlar raporlandığında runtime doğrulan
 
 Bu kanıtlar yoksa belge yalnız **dahil**, **opsiyonel** veya **doğrulanmadı** diyebilir; production garantisi veremez.
 
+## Doğrulanmış Topluluk Studio Ekleri
+
+| Yetenek | Doğrulanmış sınır |
+|---|---|
+| Operations kartları | İç Management API üzerinden salt okunur servis sağlığı ve deploy commit'i. |
+| Usage kartları | Self-host Logflare ham tablolarından son 24 saat toplamı. |
+| Observability Lite | Yalnız Query Performance; Cloud control-plane raporları kapalı kalır. |
+| Dashboard Preferences | Tarayıcıya yerel tercihler; Platform API veya billing bağımlılığı yoktur. |
+| Function Secrets | Redacted CRUD, kalıcı named volume ve Edge Runtime hot reload. |
+
+Backup ve migration kartları yalnız operatörün yayınladığı durum kanıtını
+gösterir. Panel henüz backup oluşturmaz, restore çalıştırmaz veya migration
+uygulamaz.
+
 Belge güncelleme kuralları: [DOCUMENTATION-MAINTENANCE.md](./DOCUMENTATION-MAINTENANCE.md).


### PR DESCRIPTION
Operations, Usage, Observability Lite, Dashboard Preferences ve Function Secrets durumlarını Türkçe/İngilizce günceller. Eski env+restart modelini izole named-volume/hot-reload sözleşmesiyle değiştirir. Backup/migration yüzeylerinin yalnız kanıt gösterdiğini açıkça korur.