### PR TITLE
📚 Supabase Türkiye: Public dashboard durumunu netleştir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added Operations and Usage cards backed by self-hosted services.
 - Added Observability Lite through Query Performance and Dashboard Preferences.
 - Added persistent, redacted Function Secrets CRUD with Edge Runtime hot reload.
+- Published the community Studio image `ghcr.io/akin-umit/supabase-studio:c5c42a3e38e77e69c12cb9e65e263ca203669c3d`.
 - Documented the failed nested-mount rollout, rollback, isolated-volume fix, and
   successful stable redeployment.
 

--- a/DASHBOARD-ROADMAP.md
+++ b/DASHBOARD-ROADMAP.md
@@ -66,3 +66,28 @@ kaydi ve rollback davranisi tanimlanmadan ozellik tamamlandi sayilmaz.
 - Yalniz kanit gosterir: backup ve migration durum kartlari.
 - Kalan: backup/restore job calistirma, migration uygulama ve ayri coklu proje
   control plane.
+
+## 2026-07-12 Durum Notu
+
+Topluluk Studio imaji artik self-host icin temel panel bosluklarini kapatan ilk
+paketi icerir: servis sagligi, deploy commit bilgisi, Logflare tabanli usage
+kartlari, Observability Lite, Dashboard Preferences ve kalici Function Secrets.
+
+Bu asama Supabase Cloud'un birebir kopyasi degildir. Cloud ekranlarindaki
+compute, request basari orani, altyapi haritasi, backup, migration, organization,
+team, proje olusturma ve billing verileri Supabase Platform control plane
+API'lerinden gelir. Self-host dagitimda bu veriler ancak kendi management API ve
+job runner katmanimizla uretilebilir.
+
+Siradaki kucuk paketler:
+
+1. Logflare verisinden API Gateway, Edge Functions, Postgres, Storage, Realtime
+   ve Auth icin daha zengin usage kartlari.
+2. Management API uzerinden sanitize altyapi ozeti ve connection bilgileri.
+3. Backup ve migration kartlarinda sadece "var/yok" yerine operator kaniti ve
+   runbook baglantisi.
+4. Panelden backup/restore/migration calistirmadan once yetkili, idempotent ve
+   audit loglu job runner tasarimi.
+
+Bu siralama korunacak: once read-only kanit, sonra kontrollu operasyon, en son
+coklu proje control plane.

--- a/versions.md
+++ b/versions.md
@@ -1,5 +1,8 @@
 # Docker Image Versions
 
+## 2026-07-12
+- ghcr.io/akin-umit/supabase-studio:c5c42a3e38e77e69c12cb9e65e263ca203669c3d (community Studio image with Operations, Usage, Observability Lite, Dashboard Preferences and Function Secrets isolation)
+
 ## 2026-07-07
 - supabase/studio:2026.07.07-sha-a6a04f2 (prev supabase/studio:2026.06.03-sha-0bca601)
 


### PR DESCRIPTION
## Özet

- Public roadmap'e 2026-07-12 durum notu ekler.
- Topluluk Studio imajını changelog ve versions belgelerine ekler.
- Supabase Cloud control-plane farkını ve sıradaki read-only/job-runner/control-plane aşamalarını private bilgi sızdırmadan açıklar.

## Doğrulama

- git diff --check
- rg ile OpenBase/eski hash/not-yet kalıntısı kontrolü
- rg ile credential pattern kontrolü
- node --test management-api/server.test.mjs

## Not

- Lokal Windows ortamında docker, bash ve sh PATH'te olmadığı için Compose config ve shell testleri yerelde çalışmadı; GitHub CI çalıştıracak.