### PR TITLE
📚 Supabase Türkiye: Coolify hata rehberini netleştir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Coolify gateway and acceptance documentation - 2026-07-14
+
+- Documented why Kong host-port publishing was separated from the Coolify base
+  Compose path: host port `8000` can belong to the Coolify layer, while public
+  Supabase traffic must route through the HTTPS domain to the internal
+  `kong:8000` backend.
+- Documented why Kong should not wait for Studio health before the public
+  gateway can start. A temporary Studio health issue must not block Auth, REST,
+  Storage, Realtime or Functions routes.
+- Added Turkish and English troubleshooting guides with a compact symptom map
+  for `503`, `401 Basic`, `401 Key`, Edge Runtime empty-root responses and
+  network-alias failures.
+- Clarified Gate 3/Gate 4 order: read-only route stability comes before
+  temporary Auth user, Storage bucket, Function invoke or Realtime write smoke.
+- Updated dashboard roadmap wording so operators can distinguish completed,
+  evidence-only, partial and not-started areas without reading private rollout
+  logs.
+
 ## Self-hosted Studio operations and secrets - 2026-07-12
 
 - Added Operations and Usage cards backed by self-hosted services.

--- a/COOLIFY.md
+++ b/COOLIFY.md
@@ -24,6 +24,12 @@ Tam sifir kurulum ve platform bagimsiz kurulum icin [DEPLOYMENT.md](./DEPLOYMENT
    - Ornek: `supabase.example.com`
    - Mevcut production kaynagi migration bitene kadar korunur.
    - Yalniz `kong` servisine domain verilir.
+   - Coolify UI ayri service/internal port alani gosteriyorsa:
+     - Domain: `https://supabase.example.com`
+     - Service/internal port: `8000`
+   - Coolify UI tek domain input'u kullaniyorsa domain `https://supabase.example.com:8000` girilir. Buradaki `:8000` kullanicinin acacagi host portu degil, Coolify proxy'nin container icindeki `kong:8000` hedefine yonelmesi icindir.
+   - Kullanicilar her iki durumda da disaridan `https://supabase.example.com` adresini acar.
+   - Host port publish edilmez.
    - Studio, auth, rest, realtime, storage, functions, meta ve supavisor icin ayri public domain uretilmez.
 
 4. Env:
@@ -67,6 +73,9 @@ Bu repo ile:
 
 ## Bilinen Coolify Tuzaklari
 
+- `https://supabase.example.com` `503 Service Unavailable` donduruyorsa sorun genellikle API key degil, Coolify proxy'nin `kong` backend'ine ulasamamasidir. Once domainin yalniz `kong` servisine bagli oldugunu, backend/internal portun `8000` oldugunu, Compose dosyasinin yeniden yuklenip kaydedildigini ve `kong` health durumunu kontrol et.
+- Tarayicida `http://supabase.example.com:8000` acildiginda Coolify login'e gidiyorsa bu host portunun Coolify tarafinda oldugunu gosterir; kullanicilar bu adresi kullanmaz. Public trafik `https://supabase.example.com` uzerinden Coolify proxy ile `kong:8000` internal portuna gitmelidir.
+- Base Compose Coolify icin host `ports` yayinlamaz. Yerel CLI testlerinde host port gerekiyorsa yalniz local override dosyasi kullanilir; Coolify deploy'a dahil edilmez.
 - Runtime dizininde `volumes/db/*.sql`, `volumes/api/kong.yml` veya `volumes/pooler/pooler.exs` dosya yerine klasor olursa bind mount kaynagi kayiptir. Deployment durdurulur; repo korunumu ve compose yolu duzeltilir.
 - Kong `name resolution failed` verirse compose network aliaslari kontrol edilir: `supabase-studio`, `supabase-edge-functions`, `realtime-dev.supabase-realtime`.
 - `POSTGRES_HOST`, `POSTGRES_HOSTNAME` dahili olarak `db`; dahili port `5432` olmalidir. Dis port yalniz host erisimi icindir.
@@ -75,3 +84,57 @@ Bu repo ile:
 - Vector calisiyor fakat `unhealthy` gorunuyorsa health endpointinde `localhost` yerine servis icinden `127.0.0.1` veya Compose aginda `vector` adini kullan; `localhost` IPv6 `::1` olarak cozulebilir.
 - Runtime log testlerinde Compose proje adini sabitleme. `tests/test-container-logs.sh` varsayilan olarak calisma dizinini kullanir; gerekirse `COMPOSE_PROJECT_NAME` ile acikca ver.
 - Edge Functions secret modeli ve Coolify `env_file` fallback'i icin [FUNCTION-SECRETS.md](./FUNCTION-SECRETS.md) belgesini kullan.
+
+## Hata Haritasi
+
+| Belirti | Anlami | Sonraki kontrol |
+|---|---|---|
+| `https://supabase.example.com` -> `503` | Coolify proxy saglikli backend bulamiyor. | Deploy commit, `Reload Compose File`, domainin `kong` servisine baglanmasi, internal port `8000`, `kong`/`studio`/`storage`/`auth`/`functions` health. |
+| `http://supabase.example.com:8000` -> Coolify login | Host port 8000 Coolify katmaninda. | Bu URL'yi kullanma; public HTTPS domainini `kong:8000` backend'ine route et. |
+| Studio root -> `401 Basic` | Korumali Studio girisi calisiyor. | Giris bilgileriyle UI smoke testlerini calistir. |
+| Auth/REST -> `401 Key` | API key olmadan beklenen ret. | Key testlerini yalniz kontrollu smoke ortaminda yap. |
+| Functions root -> `missing function name` | Edge Runtime'a ulasildi ama function path verilmedi. | Bilinen bir function path'i ile Gate 4 testinde cagir. |
+
+## Degisiklik Nedeni Arsivi
+
+Bu bolum kullaniciyi loglara bogmadan, neden eski onerinin degistigini kaydeder.
+
+### Kong host port yayini ayrildi
+
+- Eski yapi: Kong host `8000` portuna publish edilebiliyordu.
+- Sorun: Bazi Coolify kurulumlarinda host `8000` Coolify paneli veya proxy
+  katmani tarafindan kullanilir. Bu durumda `http://domain:8000` Supabase degil
+  Coolify login acabilir.
+- Yeni yapi: Coolify base Compose public host port yayinlamaz; domain proxy
+  `kong:8000` internal portuna yonlendirilir. Yerel test gerekiyorsa local
+  override kullanilir.
+- Kullanici ne yapmali: Tarayicida `:8000` ile gezmemeli; public HTTPS domaini
+  uzerinden test etmeli.
+
+### Kong, Studio health sonucunu beklememeli
+
+- Eski yapi: Kong baslamadan once Studio health durumunu bekleyebiliyordu.
+- Sorun: Studio gecici olarak sagliksizsa veya login/proxy ayari degisiyorsa
+  public gateway de kilitlenebilir ve tum route'lar `503` verebilir.
+- Yeni yapi: Kong yalniz Studio container start durumuna bagli kalir; public
+  gateway Studio health sonucundan bagimsiz ayakta kalabilir.
+- Kullanici ne yapmali: `503` gorurse once `kong` ve domain/backend port
+  sagligini kontrol etmeli; bunu API key hatasiyla karistirmamali.
+
+### Coolify domain port notu netlestirildi
+
+- Eski anlatim: `:8000` ifadesi kullanicinin tarayicida acacagi port gibi
+  anlasilabiliyordu.
+- Sorun: Coolify UI varyantlarinda `:8000` bazen backend/internal port bilgisidir,
+  bazen ayri service port alaninda verilir. Bu ayrim karisinca route `503`
+  veya Coolify login yonlendirmesi gorulebilir.
+- Yeni anlatim: Ayri port alani varsa domain portsuz, service/internal port
+  `8000`; tek domain input'u varsa `https://supabase.example.com:8000` backend
+  hedefini ifade eder. Dis kullanici yine `https://supabase.example.com` acar.
+
+## Kabul Sirasi
+
+1. Once read-only Gate 3: public route, Kong, Auth, REST, Storage, Functions ve Supavisor saglik/ret kodlari.
+2. Gate 3 birden fazla ard arda kontrolde stabil degilse Auth user, Storage bucket veya Realtime gibi yazmali testlere gecme.
+3. Gate 4 yazmali testler yalniz sentetik veriyle yapilir ve test sonunda temizlenir.
+4. Gate 5 Studio UI testi Basic auth girisinden sonra API Keys, Auth, Storage, Functions ve Logs sayfalarini tek tek kontrol eder.

--- a/DASHBOARD-ROADMAP.en.md
+++ b/DASHBOARD-ROADMAP.en.md
@@ -68,3 +68,41 @@ loading/error state, tests, audit evidence, and rollback behavior are defined.
 - Evidence-only: backup and migration status cards.
 - Remaining: backup/restore job execution, migration execution, and a separate
   multi-project control plane.
+
+## Not Accepted or Easy to Misread
+
+- If the public route returns `503`, dashboard or API-key smoke is not accepted.
+  Fix Coolify/Kong backend health first.
+- Gate 4 write smoke must not run until Gate 3 read-only routes are stable.
+- A Cloud card being present in the Studio source does not mean a self-host
+  backend exists for it.
+- Backup and migration cards currently show operator evidence only; the panel
+  does not yet create backups, run restores, or apply migrations.
+
+## Operator Summary
+
+| Area | Status | Note |
+|---|---|---|
+| Self-host runtime foundation | Partially complete | Compose, key/JWKS, Function Secrets, Logflare/Vector, and the management API foundation exist. |
+| Coolify deployment | Partially complete | Domain/backend-port and host-port traps are documented; every live environment still needs smoke evidence. |
+| Cloud-like dashboard | Partial | Some cards exist; Cloud compute/topology/backup/PITR/project factory are not available yet. |
+| Multi-project platform | Not started | Requires a separate orchestrator/control-plane product. |
+
+Rough progress estimate: self-host runtime foundation 60-65 percent, Coolify
+documentation 70 percent, Cloud-like dashboard 25-30 percent, multi-project
+control plane 0-10 percent. These numbers are scope markers, not release
+guarantees.
+
+## 2026-07-14 Status Note
+
+Two lessons from the Coolify/Kong work are now part of the public guidance:
+
+1. Kong, the public gateway, must not be blocked by Studio health. Studio can be
+   temporarily unhealthy while the gateway still needs to carry public routes.
+2. Coolify domain routing is not the same as host-port publishing. Users browse
+   `https://supabase.example.com`; the Coolify proxy targets the container's
+   internal `kong:8000` backend.
+
+This note is generic community guidance. In production, the final answer still
+comes from container health, deployed commit, Compose config, and read-only
+smoke evidence.

--- a/DASHBOARD-ROADMAP.md
+++ b/DASHBOARD-ROADMAP.md
@@ -67,6 +67,30 @@ kaydi ve rollback davranisi tanimlanmadan ozellik tamamlandi sayilmaz.
 - Kalan: backup/restore job calistirma, migration uygulama ve ayri coklu proje
   control plane.
 
+## Kabul Edilmeyen veya Karistirilmamasi Gerekenler
+
+- Public route `503` donduruyorsa dashboard veya API key testi basarili
+  sayilmaz. Once Coolify/Kong backend sagligi duzeltilir.
+- Gate 4 yazmali smoke testleri, Gate 3 read-only route stabil olmadan
+  calistirilmaz.
+- Cloud ekraninda gorunen bir kartin Studio kaynak kodunda bulunmasi, self-host
+  backendinin hazir oldugu anlamina gelmez.
+- Backup ve migration kartlari su an operator kaniti gosterir; panel henuz
+  backup olusturmaz, restore calistirmaz veya migration uygulamaz.
+
+## Operator Icin Kisa Durum
+
+| Alan | Durum | Not |
+|---|---|---|
+| Self-host runtime temeli | Kismi tamam | Compose, key/JWKS, Function Secrets, Logflare/Vector ve management API temeli var. |
+| Coolify kurulumu | Kismi tamam | Domain/backend port ve host-port tuzaklari belgelendi; canli deploy her ortamda ayrica smoke ister. |
+| Dashboard Cloud benzerligi | Kismi | Bazi kartlar var, Cloud compute/topology/backup/PITR/proje fabrikasi yok. |
+| Coklu proje platformu | Baslamadi | Ayri orchestrator/control-plane urunu gerekir. |
+
+Tahmini ilerleme: self-host runtime temeli yuzde 60-65, Coolify dokumantasyonu
+yuzde 70, Cloud benzeri dashboard yuzde 25-30, coklu proje control plane yuzde
+0-10 seviyesindedir. Bu oranlar release garantisi degil, kapsam okumasidir.
+
 ## 2026-07-12 Durum Notu
 
 Topluluk Studio imaji artik self-host icin temel panel bosluklarini kapatan ilk
@@ -91,3 +115,17 @@ Siradaki kucuk paketler:
 
 Bu siralama korunacak: once read-only kanit, sonra kontrollu operasyon, en son
 coklu proje control plane.
+
+## 2026-07-14 Durum Notu
+
+Coolify/Kong calismalarinda iki onemli ders netlesti:
+
+1. Kong public gateway, Studio health sonucuna baglanmamalidir. Studio gecici
+   olarak sagliksiz olsa bile gateway public route'lari tasiyabilmelidir.
+2. Coolify domain routing ile host port yayini ayni sey degildir. Kullanici
+   `https://supabase.example.com` adresini acar; Coolify proxy backend olarak
+   container icindeki `kong:8000` portuna gider.
+
+Bu not, public community icin geneldir. Her production ortaminda son karar
+container health, deploy commit, Compose config ve read-only smoke kanitiyla
+verilir.

--- a/PLATFORM-CAPABILITIES.en.md
+++ b/PLATFORM-CAPABILITIES.en.md
@@ -47,6 +47,11 @@ GitHub Actions validates base Compose and shell syntax. That is not production r
 
 The presence of optional files does not guarantee that every overlay combination is supported. Validate each selected combination separately.
 
+If the public domain returns `503 Service Unavailable`, that deployment is not
+accepted as verified. Check the Coolify/Kong backend route, service health,
+internal port `8000`, and Compose reload state before running write smoke tests
+for Auth, Storage, or Realtime.
+
 ## Not Provided by Self-Hosting
 
 - Cloud organization and multi-project control plane

--- a/PLATFORM-CAPABILITIES.md
+++ b/PLATFORM-CAPABILITIES.md
@@ -38,6 +38,11 @@ bagli degildir. Ayrintilar: [MANAGEMENT-API.md](./MANAGEMENT-API.md).
 
 Temel Compose ve shell kontrolleri GitHub Actions içinde çalışır. Bu doğrulama containerların production verisiyle canlı smoke test edildiği anlamına gelmez.
 
+Public domain `503 Service Unavailable` donduruyorsa ilgili deployment
+dogrulanmis sayilmaz. Bu durumda once Coolify/Kong backend route, service
+health, internal port `8000` ve Compose reload durumu kontrol edilir; yazmali
+Auth/Storage/Realtime smoke testlerine gecilmez.
+
 ## Opsiyonel Bileşenler
 
 | Yetenek | Durum | Etkinleştirme ve kanıt |

--- a/README.en.md
+++ b/README.en.md
@@ -41,6 +41,7 @@ This project turns those operational lessons into a reusable, Git-managed distri
 | I am migrating from Supabase Cloud | [Migration guide](./MIGRATION.md) |
 | My stack is already running | [Operations guide](./OPERATIONS.md) |
 | I need capability and Cloud parity details | [Platform capabilities](./PLATFORM-CAPABILITIES.en.md) |
+| I see a 503 or gateway error | [Troubleshooting](./docs/TROUBLESHOOTING.en.md) |
 | I want to contribute | [Contribution guide](./CONTRIBUTING.md) |
 
 ## Important: One Stack Is One Project

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Rehber sana sırayla şunları yaptırır:
 | Bir hata aldım | [Türkçe hata kontrol listesi](./docs/TURKCE-KURULUM.md#sik-hatalar) |
 | Katkı yapmak istiyorum | [Katkı rehberi](./CONTRIBUTING.md) |
 
+503, gateway timeout veya Coolify route hatasi gorursen once [Sorun giderme](./docs/TROUBLESHOOTING.md) sayfasini oku. Bu sayfa hangi hata kodunun ne anlama geldigini ve Gate 3/Gate 4 test siralamasini ayirir.
+
 ## Önemli Gerçek: Tek Kurulum Tek Projedir
 
 Self-hosted Supabase Studio, Supabase Cloud'daki gibi aynı panelden sınırsız yeni proje oluşturmaz. Bu Docker yapısında **bir stack bir Supabase projesidir**. İkinci bağımsız proje için ikinci stack, ayrı veritabanı, ayrı domain ve ayrı secret seti gerekir.
@@ -113,6 +115,7 @@ Arama, yapay zekâ ve dokümantasyon araçları için proje kaynak haritası [ll
 - [Türkçe resimli başlangıç](./docs/TURKCE-KURULUM.md)
 - [Kurulum seçenekleri](./DEPLOYMENT.md)
 - [Coolify ayarları](./COOLIFY.md)
+- [Sorun giderme](./docs/TROUBLESHOOTING.md)
 - [Edge Functions secret yonetimi](./FUNCTION-SECRETS.md)
 - [Dashboard ve control-plane yol haritasi](./DASHBOARD-ROADMAP.md)
 - [Salt okunur operasyon Management API](./MANAGEMENT-API.md)

--- a/docs/TROUBLESHOOTING.en.md
+++ b/docs/TROUBLESHOOTING.en.md
@@ -1,0 +1,58 @@
+# Troubleshooting
+
+[Turkce](./TROUBLESHOOTING.md)
+
+This page is a short decision tree for operators so they do not get lost in
+logs and HTTP errors. Do not share secrets, real domains, or production data.
+
+## First Split
+
+1. What HTTP code does `https://supabase.example.com` return?
+2. Does Coolify show the expected deployed commit?
+3. After a Compose change, did you run `Reload Compose File` and `Save`?
+4. Is the public domain attached only to the `kong` service?
+5. Is the domain backend/internal port `8000`?
+
+## Common Symptoms
+
+| Symptom | Likely cause | What to do |
+|---|---|---|
+| `503 Service Unavailable` | Coolify proxy has no healthy backend. | Check `kong` health, domain-service mapping, internal port `8000`, restart counts, and deployed commit. |
+| `http://supabase.example.com:8000` opens Coolify login | Host port 8000 belongs to the Coolify layer. | Do not use that URL; route the public HTTPS domain to the `kong:8000` backend. |
+| `401 Basic` | Studio entry is protected and the route is alive. | Log in with the deployment username/password. |
+| `401 Key` | Expected rejection without an API key. | Run anon/service/publishable/secret key smoke in a controlled environment. |
+| `missing function name in request` | Edge Runtime is reachable but no function path was provided. | Test a known function path. |
+| `name resolution failed` | Compose network alias is missing or an old Compose model is running. | Check `supabase-studio`, `supabase-edge-functions`, and `realtime-dev.supabase-realtime` aliases. |
+
+## Why Did These Settings Change?
+
+Short answer: the old layout could appear to work in some Coolify deployments,
+but once host ports and proxy backend ports were confused, users either landed
+on the Coolify login page or the public HTTPS domain returned `503`.
+
+- Kong host-port publishing was separated from the base Compose file.
+- The Coolify domain is documented as belonging only to the `kong` service.
+- The backend/internal port is explicitly `8000`.
+- Gate 4 write smoke must not run before Gate 3 read-only routes are stable.
+
+These changes do not change Supabase API behavior. They make public routing and
+operator acceptance more predictable.
+
+## Gate Order
+
+- **Gate 3 read-only:** route, health, and expected rejection codes. Writes no
+  data.
+- **Gate 4 temporary-data:** creates synthetic Auth user, Storage bucket,
+  Function invocation, and Realtime channel; then cleans them up.
+- **Gate 5 Studio UI:** checks Studio pages visually and behaviorally after
+  Basic auth login.
+
+Do not run Gate 4 while Gate 3 is unstable.
+
+## Reporting
+
+- Report HTTP code, endpoint, expected result, and actual result.
+- Do not share secret values, cookies, tokens, real customer data, or private
+  domains.
+- Do not say "working" without deployed commit, service health, and smoke
+  evidence.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,59 @@
+# Sorun Giderme
+
+[English](./TROUBLESHOOTING.en.md)
+
+Bu sayfa, kurulum yapan kisinin hata mesajlari arasinda kaybolmamasi icin kisa
+karar agaci verir. Secret, gercek domain ve production veri paylasma.
+
+## Once Ayir
+
+1. `https://supabase.example.com` hangi HTTP kodunu donduruyor?
+2. Coolify deploy edilen commit'i son beklenen commit mi?
+3. Compose dosyasi degisiklikten sonra `Reload Compose File` ve `Save` ile
+   yeniden yuklendi mi?
+4. Public domain yalniz `kong` servisine mi bagli?
+5. Domain backend/internal portu `8000` mi?
+
+## Yaygin Belirtiler
+
+| Belirti | Muhtemel neden | Ne yapmali |
+|---|---|---|
+| `503 Service Unavailable` | Coolify proxy saglikli backend bulamiyor. | `kong` health, domain-service eslesmesi, internal port `8000`, restart sayilari ve deploy commit kontrol edilir. |
+| `http://supabase.example.com:8000` Coolify login acar | Host port 8000 Coolify katmanina ait. | Bu adres kullanilmaz; public HTTPS domaini `kong:8000` backend'ine route edilir. |
+| `401 Basic` | Studio girisi korumali ve route calisiyor. | Deployment kullanici adi/parolasi ile giris yap. |
+| `401 Key` | API key olmadan beklenen ret. | Anon/service/publishable/secret key smoke testini kontrollu ortamda yap. |
+| `missing function name in request` | Edge Runtime'a ulasildi, function path eksik. | Bilinen function path'i ile test et. |
+| `name resolution failed` | Compose network aliasi eksik veya eski compose calisiyor. | `supabase-studio`, `supabase-edge-functions`, `realtime-dev.supabase-realtime` aliaslarini kontrol et. |
+
+## Neden Bu Ayarlar Degisti?
+
+Kisa cevap: Eski yapi bazi Coolify kurulumlarinda calisiyor gibi gorunse de,
+host portu ve proxy backend portu karisinca kullanici ya Coolify login ekranina
+gidiyor ya da public HTTPS domaini `503` donduruyordu.
+
+- Kong host port yayini base Compose'tan ayrildi.
+- Coolify domaini yalniz `kong` servisine baglanacak sekilde netlestirildi.
+- Backend/internal portun `8000` oldugu acik yazildi.
+- Gate 3 read-only route stabil olmadan Gate 4 yazmali testlerin
+  calistirilmamasi kural haline getirildi.
+
+Bu degisiklikler Supabase API davranisini degistirmek icin degil, public route
+ve operator kabul surecini daha tahmin edilebilir yapmak icindir.
+
+## Gate Sirasi
+
+- **Gate 3 read-only:** route, health ve beklenen ret kodlari. Veri yazmaz.
+- **Gate 4 temporary-data:** sentetik Auth user, Storage bucket, Function invoke
+  ve Realtime channel olusturur; sonunda temizler.
+- **Gate 5 Studio UI:** Basic auth sonrasi Studio sayfalarini gorsel ve
+  davranissal olarak kontrol eder.
+
+Gate 3 stabil degilse Gate 4 calistirma.
+
+## Rapor Yazarken
+
+- HTTP kodunu, hangi endpointi ve beklenen/gercek sonucu yaz.
+- Secret degeri, cookie, token, gercek musteri verisi veya private domain
+  paylasma.
+- `calisiyor` demek icin en az deploy commit, service health ve smoke kaniti
+  gerekir.


### PR DESCRIPTION
## Türkçe

Bu PR, private ortamda doğrulanan ama özel bilgi içermemesi gereken Coolify/Gateway derslerini public community dokümanlarına taşır.

Eklenenler:
- Coolify domain/backend port açıklaması
- `503`, `401 Basic`, `401 Key`, Edge Runtime ve network alias hata haritası
- Gate 3 read-only ve Gate 4 yazmalı smoke ayrımı
- Dashboard roadmap için tamamlanan/kısmi/kalan kapsam özeti
- Değişiklik nedeni arşivi: eski yapı neden sorunluydu, yeni yapı neyi çözüyor

Özel domain, IP, Coolify ID, private commit veya secret değeri eklenmedi.

## English

This PR publishes sanitized Coolify/Gateway lessons from the private rollout to the public community docs.

It adds:
- Coolify domain/backend port guidance
- Troubleshooting maps for `503`, `401 Basic`, `401 Key`, Edge Runtime, and network alias errors
- Gate 3 read-only vs Gate 4 write-smoke ordering
- Dashboard roadmap status boundaries
- A concise change-reason archive explaining why the old layout changed

No private domain, IP, Coolify ID, private commit, or secret value is included.

## Verification

- `git diff --check`
- Private identity scan: no matches
- Local markdown link check: passed for 39 markdown files
- `node --test management-api/server.test.mjs`

Local Docker/bash/sh were not available on this Windows PATH; GitHub CI will run Compose, shell, function-secret, management-status and lychee checks.