### PR TITLE
📚 Supabase Türkiye: Belge geçmişi bağlama kuralı ekle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@
   evidence-only, partial and not-started areas without reading private rollout
   logs.
 
+Related operator documents:
+
+- [Coolify setup notes](./COOLIFY.md#degisiklik-nedeni-arsivi)
+- [Turkish troubleshooting guide](./docs/TROUBLESHOOTING.md#neden-bu-ayarlar-degisti)
+- [English troubleshooting guide](./docs/TROUBLESHOOTING.en.md#why-did-these-settings-change)
+- [Dashboard roadmap](./DASHBOARD-ROADMAP.md#2026-07-14-durum-notu)
+- [Dashboard roadmap English](./DASHBOARD-ROADMAP.en.md#2026-07-14-status-note)
+- [Documentation maintenance contract](./DOCUMENTATION-MAINTENANCE.md#degisiklik-gecmisi-baglama-kurali)
+
 ## Self-hosted Studio operations and secrets - 2026-07-12
 
 - Added Operations and Usage cards backed by self-hosted services.

--- a/COOLIFY.md
+++ b/COOLIFY.md
@@ -98,6 +98,7 @@ Bu repo ile:
 ## Degisiklik Nedeni Arsivi
 
 Bu bolum kullaniciyi loglara bogmadan, neden eski onerinin degistigini kaydeder.
+Tum tarihsel ozet ve ilgili belge baglantilari icin [CHANGELOG.md](./CHANGELOG.md#coolify-gateway-and-acceptance-documentation---2026-07-14) kaydina bak.
 
 ### Kong host port yayini ayrildi
 

--- a/DOCUMENTATION-MAINTENANCE.md
+++ b/DOCUMENTATION-MAINTENANCE.md
@@ -15,8 +15,8 @@ Kod, Compose, script veya test değişikliği ilgili belgeler güncellenmeden ta
 
 | Değişiklik | Aynı PR'da kontrol edilecek belgeler |
 |---|---|
-| Base Compose servisi, port, volume, network veya env | `README.md`, `README.en.md`, `PLATFORM-CAPABILITIES*.md`, `CONFIG.md`, `DEPLOYMENT.md` |
-| Coolify kaynak/kurulum davranışı | `COOLIFY.md`, `docs/TURKCE-KURULUM.md`, `docs/ENGLISH-SETUP.md` |
+| Base Compose servisi, port, volume, network veya env | `README.md`, `README.en.md`, `PLATFORM-CAPABILITIES*.md`, `CONFIG.md`, `DEPLOYMENT.md`, `CHANGELOG.md` |
+| Coolify kaynak/kurulum davranışı | `COOLIFY.md`, `docs/TURKCE-KURULUM.md`, `docs/ENGLISH-SETUP.md`, `docs/TROUBLESHOOTING*.md`, `CHANGELOG.md` |
 | Auth, API key, JWT veya secret modeli | `CONFIG.md`, iki kurulum rehberi, `SECURITY.md`, gerekirse migration/rollback |
 | Backup, restore, migration veya PostgreSQL upgrade | `OPERATIONS.md`, `MIGRATION.md`, `DEPLOYMENT.md`, `CHANGELOG.md` |
 | Image/tag güncellemesi | `CHANGELOG.md`, `versions.md`, capability/uyumluluk notları |
@@ -25,6 +25,25 @@ Kod, Compose, script veya test değişikliği ilgili belgeler güncellenmeden ta
 | Upstream aday değişiklik | `UPSTREAM-CONTRIBUTIONS.md`, ilgili Issue/PR bağlantısı |
 
 Etkilenmeyen belge için PR açıklamasında kısa gerekçe yazılır. “Belge gerekmiyor” işaretlemek inceleme sorumluluğunu kaldırmaz.
+
+## Degisiklik Gecmisi Baglama Kurali
+
+Davranis, kurulum, port, domain, proxy, secret, backup, migration, dashboard
+veya kabul testi mantigi degistiginde `CHANGELOG.md` ana tarihsel indeks olarak
+guncellenir. Ilgili rehberler de kendi iclerinden bu changelog kaydina geri
+baglanir.
+
+Her boyle PR su sorulara kisa cevap vermelidir:
+
+1. Eski yapi neydi?
+2. Eski yapida hangi hata veya belirsizlik goruldu?
+3. Yeni yapi neyi degistiriyor?
+4. Kullanicinin yapmasi gereken net aksiyon nedir?
+5. Hangi belgeler bu degisiklige baglandi?
+
+Bu cevaplar kullaniciyi terminal loglarina bogmadan okunabilir olmalidir. Detay
+gerekiyorsa changelog ana kayit, rehberler ise pratik uygulama sayfasi olarak
+kalir.
 
 ## Testten Merge'e Akış
 

--- a/docs/TROUBLESHOOTING.en.md
+++ b/docs/TROUBLESHOOTING.en.md
@@ -30,6 +30,8 @@ Short answer: the old layout could appear to work in some Coolify deployments,
 but once host ports and proxy backend ports were confused, users either landed
 on the Coolify login page or the public HTTPS domain returned `503`.
 
+The historical summary and linked documents for this change live in [CHANGELOG.md](../CHANGELOG.md#coolify-gateway-and-acceptance-documentation---2026-07-14).
+
 - Kong host-port publishing was separated from the base Compose file.
 - The Coolify domain is documented as belonging only to the `kong` service.
 - The backend/internal port is explicitly `8000`.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -31,6 +31,8 @@ Kisa cevap: Eski yapi bazi Coolify kurulumlarinda calisiyor gibi gorunse de,
 host portu ve proxy backend portu karisinca kullanici ya Coolify login ekranina
 gidiyor ya da public HTTPS domaini `503` donduruyordu.
 
+Bu degisikligin tarihsel ozeti ve bagli belgeleri [CHANGELOG.md](../CHANGELOG.md#coolify-gateway-and-acceptance-documentation---2026-07-14) icinde tutulur.
+
 - Kong host port yayini base Compose'tan ayrildi.
 - Coolify domaini yalniz `kong` servisine baglanacak sekilde netlestirildi.
 - Backend/internal portun `8000` oldugu acik yazildi.


### PR DESCRIPTION
## Türkçe

Bu PR, davranış/kurulum değişikliklerinin tarihsel bağlamını koparmamak için belge geçmişi bağlama kuralı ekler.

Yapılanlar:
- `CHANGELOG.md` ilgili Coolify/Gateway değişikliğinin ana indeks kaydı oldu.
- `COOLIFY.md` ve troubleshooting dosyaları changelog kaydına geri bağlandı.
- `DOCUMENTATION-MAINTENANCE.md` içine zorunlu kural eklendi: davranış, port, domain, proxy, secret, backup, migration, dashboard veya kabul testi mantığı değişirse changelog ve ilgili MD bağlantıları aynı PR’da güncellenecek.
- PR açıklamasında cevaplanması gereken 5 soru eklendi: eski yapı, hata/belirsizlik, yeni yapı, kullanıcı aksiyonu, bağlı belgeler.

## English

Adds a documentation history-linking rule so behavior/setup changes do not lose their context.

## Verification

- `git diff --check`
- Local markdown link check: passed for 39 markdown files
- Private identity scan: no matches
- `node --test management-api/server.test.mjs`