### PR TITLE
📚 Supabase Türkiye: Community yayın akışını netleştir

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,12 +16,17 @@ This file applies to every human contributor, AI coding agent, and AI-assisted d
 3. Identify whether the change is documentation-only, deployment-only, security-sensitive, or an upstream candidate.
 4. Search existing Issues, Discussions, and pull requests before duplicating work.
 5. Preserve unrelated changes and keep the patch narrowly scoped.
+6. If the task depends on earlier private validation, public plans, or forum
+   updates, read `COMMUNITY-PUBLICATION-FLOW.md` before editing.
 
 ## AI and AI-Assisted Contributions
 
 - AI-generated code and documentation are allowed, but the human contributor remains responsible for every submitted line.
 - Pull requests must disclose meaningful AI assistance and name the verified areas, not private prompts or credentials.
 - Do not claim a command, deployment, migration, restore, or test was executed when it was only suggested or simulated.
+- Do not use chat history as the durable project memory. Important decisions,
+  phase status, forum-publication plans, and private-to-public promotion rules
+  must be written into repository documents.
 - Review generated commands for destructive behavior, platform assumptions, outdated versions, and secret exposure.
 - Verify changeable technical claims against current official Supabase or component documentation.
 - Never paste private chat history, credentials, customer data, production logs, internal URLs, or proprietary code into this repository.
@@ -72,6 +77,9 @@ Also verify documentation links, Turkish/English behavioral parity, secret safet
 ## Upstream Contributions
 
 - Community merge does not automatically authorize a Supabase upstream submission.
+- `akin-umit/supabase` is the clean upstream-candidate fork, not the deployment
+  repository. Read `UPSTREAM-FORK-SYNC.md` before syncing or preparing upstream
+  work.
 - Reproduce the issue against the current target repository and search existing Issues/PRs.
 - Move only the minimal generic fix and tests to a clean branch in the appropriate fork.
 - Remove community branding, platform-specific behavior, and private deployment evidence.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## Community planning and publication rules - 2026-07-14
+
+- Added a permanent private-test to public-community publication flow.
+- Defined the required separation between planned work, private validation,
+  public community release, and upstream candidates.
+- Added a forum/GitHub Discussion publication rule so public posts link back to
+  canonical repository documents instead of repeating stale or private context.
+- Added bilingual GitHub Discussions category guidance and reusable public
+  update templates.
+- Added the upstream fork sync policy for `akin-umit/supabase`, including
+  fetch-only upstream remote guidance and safe self-host baseline review rules.
+- Added an AI/new-machine handoff rule: durable project memory belongs in repo
+  documents, not in chat history.
+
+Related operator documents:
+
+- [Community publication flow](./COMMUNITY-PUBLICATION-FLOW.md)
+- [GitHub Discussions plan](./DISCUSSIONS.md)
+- [Upstream fork sync policy](./UPSTREAM-FORK-SYNC.md)
+- [Documentation maintenance contract](./DOCUMENTATION-MAINTENANCE.md#private-testten-public-yayina-akis)
+- [Dashboard roadmap](./DASHBOARD-ROADMAP.md#community-planlama-ve-forum-yayini)
+- [Platform capabilities](./PLATFORM-CAPABILITIES.md#plan-private-validation-ve-public-release-ayrimi)
+
 ## Coolify gateway and acceptance documentation - 2026-07-14
 
 - Documented why Kong host-port publishing was separated from the Coolify base

--- a/COMMUNITY-PUBLICATION-FLOW.md
+++ b/COMMUNITY-PUBLICATION-FLOW.md
@@ -1,0 +1,123 @@
+# Community Publication Flow / Community Yayin Akisi
+
+This document defines how private test-server work becomes public community
+planning, documentation, forum updates, and future AI/operator handoff context.
+
+Bu belge, private test sunucusunda yapilan isin public community planina,
+dokumantasyona, forum/Discussion guncellemelerine ve gelecekteki AI/operator
+devrine nasil tasinacagini tanimlar.
+
+## Purpose / Amac
+
+The project has three separate evidence levels:
+
+1. **Planned:** the idea is accepted as a roadmap item, but no implementation is
+   validated yet.
+2. **Private validation:** the change exists in the private test/deployment
+   environment and has passed the relevant private checks.
+3. **Public community release:** the generic, sanitized change is merged into
+   this repository with documentation, tests, and public-safe evidence.
+
+These levels must not be mixed. A private test result does not automatically
+become a public feature claim, and a public plan does not mean the feature is
+already available.
+
+Bu seviyeler karistirilmaz. Private test sonucu otomatik public ozellik iddiasi
+degildir; public planda yazan bir hedef de ozelligin hazir oldugu anlamina
+gelmez.
+
+## Private Test Server to Community Rule
+
+When a feature, fix, or operational lesson is developed on the private test
+server:
+
+1. Record the private result in the private repository with commit, date,
+   rollback note, and exact checks.
+2. Decide whether the result is `private-only`, `community-candidate`, or
+   `upstream-candidate`.
+3. For `community-candidate` work, copy only reusable behavior into a clean
+   public branch.
+4. Replace all private domains, project names, server IDs, credentials, logs,
+   screenshots, and operational evidence with neutral examples.
+5. Update the affected public documents in the same pull request.
+6. Link the change from `CHANGELOG.md` and from the practical guide that a new
+   operator will read.
+7. Publish a forum or GitHub Discussion update only after the public PR is
+   merged or clearly label it as a roadmap/request-for-feedback post.
+
+## Required Public Documentation Updates
+
+Every public feature or plan update must check these files:
+
+| Change type | Required public documents |
+|---|---|
+| Dashboard or Studio behavior | `DASHBOARD-ROADMAP*.md`, `PLATFORM-CAPABILITIES*.md`, `CHANGELOG.md` |
+| Compose, Coolify, domain, proxy, or port behavior | `COOLIFY.md`, `DEPLOYMENT.md`, `docs/TROUBLESHOOTING*.md`, `CHANGELOG.md` |
+| Secrets, API keys, JWT, Auth, or Edge Functions | `CONFIG.md`, `SECURITY.md`, `FUNCTION-SECRETS*.md`, setup guides, `CHANGELOG.md` |
+| Backup, restore, migration, or upgrade | `OPERATIONS.md`, `RESTORE-DRILL*.md`, `MIGRATION.md`, `CHANGELOG.md` |
+| Multi-project/control-plane planning | `DASHBOARD-ROADMAP*.md`, `PLATFORM-CAPABILITIES*.md`, `COMMUNITY-PUBLICATION-FLOW.md` |
+| Contributor or AI workflow | `AGENTS.md`, `CONTRIBUTING.md`, `DOCUMENTATION-MAINTENANCE.md`, this file |
+
+If a listed document is not updated, the pull request must explain why.
+
+## Forum and Discussion Publication Rule
+
+Public community posts should be short, factual, and linked back to the canonical
+repository documents.
+
+Public community paylasimlari kisa, kanitli ve ana repo belgelerine bagli
+olmalidir.
+
+Use this order:
+
+1. **Roadmap post:** describe the problem, target, and what is not available
+   yet.
+2. **Validation post:** share that a private or staging test passed, without
+   private evidence or secrets.
+3. **Release post:** link the merged public PR, changelog entry, setup guide,
+   and troubleshooting guide.
+4. **Feedback post:** ask users for reproduction details, screenshots with
+   secrets removed, and deployment environment information.
+
+Do not publish private deployment screenshots, real domains, logs, credentials,
+server IDs, Coolify IDs, or private commit links.
+
+Discussion kategori plani ve iki dilli paylasim sablonlari:
+[DISCUSSIONS.md](./DISCUSSIONS.md).
+
+Private deployment ekran goruntuleri, gercek domainler, loglar, credentiallar,
+server ID'leri, Coolify ID'leri veya private commit linkleri yayinlanmaz.
+
+## AI and New Machine Handoff Rule
+
+The repository must stay understandable after a fresh clone on a new computer or
+by a new AI agent. The minimum handoff reading order is:
+
+1. `AGENTS.md`
+2. `README.md` or `README.en.md`
+3. `PLATFORM-CAPABILITIES.md` or `PLATFORM-CAPABILITIES.en.md`
+4. `DASHBOARD-ROADMAP.md` or `DASHBOARD-ROADMAP.en.md`
+5. `CHANGELOG.md`
+6. `DOCUMENTATION-MAINTENANCE.md`
+7. This file
+8. The task-specific guide, for example `COOLIFY.md`, `FUNCTION-SECRETS.md`,
+   `OPERATIONS.md`, or `docs/TROUBLESHOOTING.md`
+
+An AI agent must not rely on chat history as the source of truth. If a fact is
+important for future work, it belongs in one of the repository documents above.
+
+## Acceptance Checklist
+
+A change is ready for public community publication only when all applicable
+items are true:
+
+- The feature state is labeled as planned, partial, evidence-only, verified, or
+  not provided.
+- The old behavior, reason for change, new behavior, and user action are
+  documented.
+- `CHANGELOG.md` links to the affected practical documents.
+- Turkish and English documents are updated when the behavior affects both
+  audiences.
+- Secret and private-data scans are clean.
+- CI and Markdown link checks pass.
+- Any forum or Discussion draft links back to the canonical repository pages.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ Human, AI-assisted, and AI-agent contributions are welcome. All contributors mus
 4. Document migration and rollback impact.
 5. Do not add customer-specific domains, credentials, or branding.
 6. Update every affected English and Turkish document in the same pull request; follow [DOCUMENTATION-MAINTENANCE.md](./DOCUMENTATION-MAINTENANCE.md).
+7. If the work came from a private test server or staging environment, follow [COMMUNITY-PUBLICATION-FLOW.md](./COMMUNITY-PUBLICATION-FLOW.md) before publishing it as a community feature.
 
 ## Turkce
 
@@ -21,3 +22,4 @@ Human, AI-assisted, and AI-agent contributions are welcome. All contributors mus
 4. Migration ve rollback etkisini belgeleyin.
 5. Musteriye ozel domain, kimlik bilgisi veya marka eklemeyin.
 6. Etkilenen Turkce ve Ingilizce belgeleri ayni Pull Request icinde guncelleyin; [DOCUMENTATION-MAINTENANCE.md](./DOCUMENTATION-MAINTENANCE.md) kurallarini uygulayin.
+7. Is private test sunucusu veya staging ortamindan geldiyse community ozelligi olarak yayinlamadan once [COMMUNITY-PUBLICATION-FLOW.md](./COMMUNITY-PUBLICATION-FLOW.md) akisini uygulayin.

--- a/DASHBOARD-ROADMAP.en.md
+++ b/DASHBOARD-ROADMAP.en.md
@@ -61,6 +61,12 @@ the open-source stack.
 A card is not complete until its backend source, authorization boundary,
 loading/error state, tests, audit evidence, and rollback behavior are defined.
 
+Every dashboard item added to the public plan must be labeled as planned,
+private validation, public release, or upstream candidate. Work that passed on a
+private test server is published to the community only after a sanitized PR,
+changelog links, and the required forum/Discussion note are prepared. Rule:
+[Community Publication Flow](./COMMUNITY-PUBLICATION-FLOW.md).
+
 ## Current Delivery Status
 
 - Completed: Operations, Usage, Observability Lite, Dashboard Preferences, and
@@ -106,3 +112,15 @@ Two lessons from the Coolify/Kong work are now part of the public guidance:
 This note is generic community guidance. In production, the final answer still
 comes from container health, deployed commit, Compose config, and read-only
 smoke evidence.
+
+## Community Planning and Discussion Posts
+
+When a dashboard or control-plane package starts:
+
+1. Add the short public plan to `DASHBOARD-ROADMAP.en.md` and, when needed,
+   `PLATFORM-CAPABILITIES.en.md`.
+2. Describe private-test work only as sanitized, generalized evidence.
+3. Do not publish a forum or GitHub Discussions update without changelog and
+   roadmap links.
+4. A new AI/operator handoff starts by reading `AGENTS.md`,
+   `COMMUNITY-PUBLICATION-FLOW.md`, this roadmap, and `CHANGELOG.md`.

--- a/DASHBOARD-ROADMAP.md
+++ b/DASHBOARD-ROADMAP.md
@@ -59,6 +59,12 @@ Platform API'lerini cagirir.
 Her kart icin backend kaynagi, yetki siniri, loading/error durumu, test, audit
 kaydi ve rollback davranisi tanimlanmadan ozellik tamamlandi sayilmaz.
 
+Public plana eklenen her dashboard isi once durum etiketi alir: plan, private
+validation, public release veya upstream candidate. Private test sunucusunda
+gecen bir is, public community'de ancak sanitize PR, changelog baglantisi ve
+gerekli forum/discussion notu hazirlandiktan sonra yayinlanir. Kural:
+[Community Publication Flow](./COMMUNITY-PUBLICATION-FLOW.md).
+
 ## Guncel Teslim Durumu
 
 - Tamamlandi: Operations, Usage, Observability Lite, Dashboard Preferences ve
@@ -129,3 +135,17 @@ Coolify/Kong calismalarinda iki onemli ders netlesti:
 Bu not, public community icin geneldir. Her production ortaminda son karar
 container health, deploy commit, Compose config ve read-only smoke kanitiyla
 verilir.
+
+## Community Planlama ve Forum Yayini
+
+Dashboard veya control-plane icin yeni bir paket acildiginda:
+
+1. Kisa public plan `DASHBOARD-ROADMAP.md` ve gerekirse
+   `PLATFORM-CAPABILITIES.md` icinde yazilir.
+2. Private testte denenen kisimlar public belgede yalniz sanitize ve genellenmis
+   sonuc olarak yer alir.
+3. Forum veya GitHub Discussions duyurusu, ilgili changelog ve roadmap linkleri
+   olmadan yayinlanmaz.
+4. Yeni AI/operator devraldiginda once `AGENTS.md`,
+   `COMMUNITY-PUBLICATION-FLOW.md`, bu roadmap ve `CHANGELOG.md` dosyalarini
+   okur.

--- a/DISCUSSIONS.md
+++ b/DISCUSSIONS.md
@@ -1,0 +1,157 @@
+# GitHub Discussions Plan / GitHub Tartisma Plani
+
+This repository uses GitHub Discussions as the public update and feedback area.
+Every important update must link back to the canonical repository documents so
+the community does not depend on chat history, screenshots, or private context.
+
+Bu repo, herkese acik duyuru ve geri bildirim alani olarak GitHub Discussions
+kullanir. Her onemli guncelleme, toplulugun sohbet gecmisi veya ozel baglama
+bagimli kalmamasi icin ana repo belgelerine link vermelidir.
+
+## Recommended Categories / Onerilen Kategoriler
+
+| Category | Turkish purpose | English purpose | Use for |
+|---|---|---|---|
+| Announcements / Duyurular | Maintainer duyurulari ve surum ozetleri | Maintainer announcements and release summaries | Merged PRs, public releases, security-safe status updates |
+| Roadmap / Yol Haritasi | Planlanan isler ve oncelik sirasi | Planned work and priority order | Dashboard phases, control-plane planning, capability gaps |
+| Help / Yardim | Kurulum ve hata cozum sorulari | Setup and troubleshooting questions | Coolify, Docker, 503, API keys, Storage/Auth issues |
+| Ideas / Fikirler | Yeni ozellik ve iyilestirme onerileri | Feature and improvement ideas | Community requests before issue/PR scope is clear |
+| Development Log / Gelistirme Gunlugu | Yapilan islerin kisa, surekli guncellenen ozeti | Short rolling updates for completed work | Weekly/daily sanitized summaries linked to changelog |
+| Show and Tell / Kurulum Paylasimlari | Kullanicilarin kendi kurulum deneyimleri | Community setup stories and demos | Public examples without secrets or private data |
+
+If GitHub Discussions uses only English category titles, put the Turkish label in
+the category description. If Turkish titles are used, put the English label in
+the description.
+
+GitHub Discussions yalniz Ingilizce kategori basliklariyla kullanilacaksa Turkce
+etiket aciklamaya yazilir. Turkce baslik kullanilacaksa Ingilizce etiket
+aciklamaya yazilir.
+
+## What Goes Into Discussions / Discussions'a Ne Yazilir?
+
+Every public update should be short and linked:
+
+- What changed?
+- Why did the old behavior change?
+- What is verified, partial, planned, or not provided?
+- Which PR, changelog entry, roadmap, or guide explains the details?
+- What should users test or report?
+
+Her public guncelleme kisa ve linkli olmalidir:
+
+- Ne degisti?
+- Eski davranis neden degisti?
+- Ne dogrulandi, ne kismi, ne plan, ne sunulmuyor?
+- Detay hangi PR, changelog, roadmap veya rehberde?
+- Kullanicilar neyi test etmeli veya bildirmeli?
+
+## Development Log Template / Gelistirme Gunlugu Sablonu
+
+```md
+## TR
+
+### Kisa ozet
+
+Bu guncellemede <konu> uzerinde calisildi.
+
+### Durum
+
+- Tamamlanan:
+- Kismi:
+- Siradaki:
+- Dogrulanmayan:
+
+### Baglantilar
+
+- Changelog:
+- Roadmap:
+- Rehber:
+- PR:
+
+## EN
+
+### Short summary
+
+This update worked on <topic>.
+
+### Status
+
+- Completed:
+- Partial:
+- Next:
+- Unverified:
+
+### Links
+
+- Changelog:
+- Roadmap:
+- Guide:
+- PR:
+```
+
+## Release Announcement Template / Surum Duyurusu Sablonu
+
+```md
+## TR
+
+### Ne yayinlandi?
+
+<Kisa aciklama>
+
+### Kullaniciyi ilgilendiren kisim
+
+<Aksiyon veya dikkat edilmesi gereken konu>
+
+### Kanit ve belgeler
+
+- Changelog:
+- Kurulum/operasyon rehberi:
+- Capability/roadmap:
+- PR:
+
+## EN
+
+### What was released?
+
+<Short explanation>
+
+### User impact
+
+<Action or important note>
+
+### Evidence and docs
+
+- Changelog:
+- Setup/operations guide:
+- Capability/roadmap:
+- PR:
+```
+
+## Safety Rules / Guvenlik Kurallari
+
+Do not post:
+
+- real domains, server IPs, Coolify resource IDs, deployment IDs, container IDs,
+  or private repository links;
+- credentials, tokens, keys, cookies, `.env` values, backup contents, database
+  rows, or production logs;
+- screenshots containing private infrastructure data;
+- claims that a feature is production-ready without linked evidence.
+
+Yayinlanmayacaklar:
+
+- gercek domain, server IP, Coolify resource ID, deployment ID, container ID veya
+  private repo linki;
+- credential, token, key, cookie, `.env` degeri, backup icerigi, database satiri
+  veya production logu;
+- private altyapi verisi iceren ekran goruntusu;
+- kanit linki olmayan production-ready iddiasi.
+
+## Canonical Links / Ana Baglantilar
+
+- [Changelog](./CHANGELOG.md)
+- [Dashboard roadmap](./DASHBOARD-ROADMAP.md)
+- [Platform capabilities](./PLATFORM-CAPABILITIES.md)
+- [Community publication flow](./COMMUNITY-PUBLICATION-FLOW.md)
+- [Documentation maintenance contract](./DOCUMENTATION-MAINTENANCE.md)
+

--- a/DOCUMENTATION-MAINTENANCE.md
+++ b/DOCUMENTATION-MAINTENANCE.md
@@ -23,6 +23,7 @@ Kod, Compose, script veya test değişikliği ilgili belgeler güncellenmeden ta
 | Yeni veya kaldırılan özellik | Türkçe/İngilizce README, iki capability belgesi, config ve operasyon belgeleri |
 | CI, contribution veya AI-agent kuralı | `AGENTS.md`, `CONTRIBUTING.md`, PR şablonu |
 | Upstream aday değişiklik | `UPSTREAM-CONTRIBUTIONS.md`, ilgili Issue/PR bağlantısı |
+| Private testten public community yayınına geçiş | `COMMUNITY-PUBLICATION-FLOW.md`, `DISCUSSIONS.md`, `CHANGELOG.md`, ilgili roadmap/capability belgeleri |
 
 Etkilenmeyen belge için PR açıklamasında kısa gerekçe yazılır. “Belge gerekmiyor” işaretlemek inceleme sorumluluğunu kaldırmaz.
 
@@ -55,6 +56,23 @@ kalir.
 6. Image veya operasyon sözleşmesi değiştiyse `CHANGELOG.md` ve `versions.md` güncellenir.
 7. CI, link ve secret kontrolleri geçmeden merge edilmez.
 8. Canlı deploy ayrı onaya tabidir. Smoke sonrası yeni kanıt gerekiyorsa takip PR'ı açılır.
+
+## Private Testten Public Yayına Akış
+
+Private test sunucusunda geliştirilen bir iş public community'de doğrudan
+"tamamlandı" diye yayınlanmaz. Önce private kanıt kaydedilir, sonra yeniden
+kullanılabilir kısım sanitize edilir, ardından public PR içinde roadmap,
+capability ve changelog bağlantıları güncellenir.
+
+Kalıcı kural ve yayın sırası:
+[COMMUNITY-PUBLICATION-FLOW.md](./COMMUNITY-PUBLICATION-FLOW.md).
+
+GitHub Discussions kategori ve iki dilli duyuru sablonlari:
+[DISCUSSIONS.md](./DISCUSSIONS.md).
+
+Yeni PC'ye klonlayan bir geliştirici veya AI agent, geçmiş sohbeti değil repo
+dokümanlarını kaynak kabul eder. Bu nedenle gelecekte hatırlanması gereken her
+karar ilgili MD dosyasına yazılır.
 
 ## Release ve Deployment Sonrası
 

--- a/PLATFORM-CAPABILITIES.en.md
+++ b/PLATFORM-CAPABILITIES.en.md
@@ -83,3 +83,18 @@ Documentation update rules: [DOCUMENTATION-MAINTENANCE.md](./DOCUMENTATION-MAINT
 
 Backup and migration cards display only operator-published status evidence. The
 dashboard does not yet create backups, execute restores, or apply migrations.
+
+## Plan, Private Validation, and Public Release
+
+Every new platform capability must use an explicit state:
+
+- **Plan:** accepted target that is not implemented yet.
+- **Private validation:** tested in our private deployment or staging
+  environment, but not yet sanitized for this public repository.
+- **Public release:** merged into this repository, CI/link/secret checks passed,
+  and linked from the changelog.
+- **Upstream candidate:** generic change that may be proposed to Supabase or a
+  component upstream repository.
+
+The same distinction applies to forum announcements and AI handoff notes. Full
+rule: [COMMUNITY-PUBLICATION-FLOW.md](./COMMUNITY-PUBLICATION-FLOW.md).

--- a/PLATFORM-CAPABILITIES.md
+++ b/PLATFORM-CAPABILITIES.md
@@ -115,3 +115,19 @@ gösterir. Panel henüz backup oluşturmaz, restore çalıştırmaz veya migrati
 uygulamaz.
 
 Belge güncelleme kuralları: [DOCUMENTATION-MAINTENANCE.md](./DOCUMENTATION-MAINTENANCE.md).
+
+## Plan, Private Validation ve Public Release Ayrimi
+
+Platform yetenegi tablosuna yeni bir madde eklenirken durum mutlaka acik
+yazilir:
+
+- **Plan:** henuz uygulanmamis hedef.
+- **Private validation:** kendi test/deployment ortamimizda denenmis, ancak
+  public community icin sanitize edilmemis is.
+- **Public release:** bu repoda merge edilmis, CI/link/secret kontrolleri
+  gecmis ve changelog'a baglanmis is.
+- **Upstream candidate:** Supabase veya bilesen upstream reposuna aday genel
+  degisiklik.
+
+Bu ayrim, forum duyurularinda ve AI handoff notlarinda da korunur. Ayrintili
+kural: [COMMUNITY-PUBLICATION-FLOW.md](./COMMUNITY-PUBLICATION-FLOW.md).

--- a/README.en.md
+++ b/README.en.md
@@ -113,11 +113,14 @@ Generate fresh keys, use HTTPS, expose only the intended gateway, restrict datab
 - [Migration](./MIGRATION.md)
 - [Platform capabilities and evidence](./PLATFORM-CAPABILITIES.en.md)
 - [AI/operator handoff](./AI-HANDOFF.md)
+- [Private-test to community publication flow](./COMMUNITY-PUBLICATION-FLOW.md)
+- [GitHub Discussions and bilingual publication plan](./DISCUSSIONS.md)
 - [Version history](./versions.md)
 - [Documentation maintenance contract](./DOCUMENTATION-MAINTENANCE.md)
 - [Official Supabase README - Turkish explained translation](./docs/SUPABASE-RESMI-README-TR.md)
 - [Official Supabase README - English original](https://github.com/supabase/supabase/blob/master/README.md)
 - [Upstream documentation sync policy](./docs/UPSTREAM-DOC-SYNC.md)
+- [Supabase fork sync policy](./UPSTREAM-FORK-SYNC.md)
 
 ## Contribution and Upstream Flow
 

--- a/README.md
+++ b/README.md
@@ -124,12 +124,15 @@ Arama, yapay zekâ ve dokümantasyon araçları için proje kaynak haritası [ll
 - [Yedek, güncelleme ve geri dönüş](./OPERATIONS.md)
 - [Supabase Cloud'dan taşıma](./MIGRATION.md)
 - [Yeni yönetici veya yapay zekâya devir](./AI-HANDOFF.md)
+- [Private testten community yayınına akış](./COMMUNITY-PUBLICATION-FLOW.md)
+- [GitHub Discussions ve iki dilli yayın planı](./DISCUSSIONS.md)
 - [Sürüm geçmişi](./versions.md)
 - [Platform yetenekleri ve gerçek durum](./PLATFORM-CAPABILITIES.md)
 - [Belge güncelleme sözleşmesi](./DOCUMENTATION-MAINTENANCE.md)
 - [Resmî Supabase README - Türkçe açıklamalı çeviri](./docs/SUPABASE-RESMI-README-TR.md)
 - [Resmî Supabase README - İngilizce orijinal](https://github.com/supabase/supabase/blob/master/README.md)
 - [Upstream belge güncelleme sistemi](./docs/UPSTREAM-DOC-SYNC.md)
+- [Supabase fork güncelleme ve upstream sync kuralı](./UPSTREAM-FORK-SYNC.md)
 
 ## English
 

--- a/UPSTREAM-CONTRIBUTIONS.md
+++ b/UPSTREAM-CONTRIBUTIONS.md
@@ -2,6 +2,11 @@
 
 Topluluk reposundaki her değişiklik Supabase'e otomatik gönderilmez. Every community change is not automatically submitted to Supabase.
 
+Fork güncelleme ve upstream sync kuralı için ayrıca
+[UPSTREAM-FORK-SYNC.md](./UPSTREAM-FORK-SYNC.md) okunmalıdır. `akin-umit/supabase`
+deployment reposu değildir; yalnız temiz upstream adayları ve Supabase kaynak
+denemeleri için kullanılır.
+
 ## Doğru Kanalı Seç / Choose the Correct Channel
 
 | Amaç / Purpose | Kanal / Channel |
@@ -36,6 +41,21 @@ Tanıtım mesajı için uygun mevcut konu: [Self-hosting: What's working (and wh
 9. Sonuç `upstream-opened`, `upstream-merged` veya `upstream-declined` olarak kaydedilir.
 
 Supabase maintainerları nihai kabul yetkisine sahiptir. Topluluk reposunda bir değişikliğin merge edilmesi upstream kabul garantisi değildir.
+
+## Fork Güncelleme Notu / Fork Sync Note
+
+`akin-umit/supabase` fork'u resmi `supabase/supabase` deposundan düzenli olarak
+fetch edilir; ancak upstream `master` körlemesine merge edilmez. Her sync önce
+hangi dosyaları etkilediğine göre sınıflandırılır:
+
+- self-hosted Docker ve image tag değişiklikleri,
+- Studio self-host davranışı,
+- Cloud control-plane-only değişiklikleri,
+- dokümantasyon veya test değişiklikleri.
+
+Yalnız self-host için gerekli ve genellenebilir parçalar private doğrulama veya
+public community PR akışına taşınır. Ayrıntılı komutlar:
+[UPSTREAM-FORK-SYNC.md](./UPSTREAM-FORK-SYNC.md).
 
 ## Supabase'e İlk Tanıtım Mesajı / Initial Introduction Draft
 

--- a/UPSTREAM-FORK-SYNC.md
+++ b/UPSTREAM-FORK-SYNC.md
@@ -1,0 +1,81 @@
+# Upstream Fork Sync Policy
+
+This document explains how `akin-umit/supabase` stays connected to the official
+`supabase/supabase` repository without losing community work or publishing
+deployment-specific changes upstream.
+
+## Repository Roles
+
+| Repository | Role |
+|---|---|
+| `supabase/supabase` | Official upstream source. Read-only for this project unless an upstream PR is intentionally opened. |
+| `akin-umit/supabase` | Clean fork for upstream-candidate work and Supabase source experiments. |
+| `supabase-turkiye-private` | Private deployment validation. Never mirrored into the fork. |
+| `supabase-turkiye-community` | Public documentation, generic tooling, and sanitized community releases. |
+
+## Local Remote Setup
+
+The local checkout of `akin-umit/supabase` must have both remotes:
+
+```bash
+git remote add upstream https://github.com/supabase/supabase.git
+git remote set-url --push upstream DISABLED
+git fetch upstream master --tags
+git fetch origin master --tags
+```
+
+`upstream` is fetch-only. Do not push directly to `supabase/supabase`.
+
+## Regular Update Check
+
+Run this before starting an upstream-candidate task or updating self-hosted
+baseline files:
+
+```bash
+git fetch upstream master --tags
+git fetch origin master --tags
+git rev-list --left-right --count origin/master...upstream/master
+git log --oneline --decorate -10 upstream/master -- docker apps/studio
+git log --oneline --decorate -10 origin/master -- docker apps/studio
+```
+
+The ahead/behind count is diagnostic only. It is not approval to reset, force
+push, or blindly merge upstream.
+
+## Safe Sync Rule
+
+Use one of these paths:
+
+1. **Upstream-candidate fix:** create a fresh branch from `upstream/master`,
+   apply only the minimal generic fix, add tests, then push to
+   `akin-umit/supabase`.
+2. **Self-hosted baseline review:** compare the current self-hosted tag or
+   commit with the new upstream tag, then copy only reviewed `docker/`,
+   `apps/studio`, or documentation changes into the private/community flow.
+3. **Fork maintenance:** if the fork default branch must be synced, first record
+   backup refs and custom branches, then use a reviewed merge or GitHub sync.
+   Do not force-push unless the owner explicitly approves the exact recovery
+   plan.
+
+## What Must Not Happen
+
+- Do not make `akin-umit/supabase` the deployment repository.
+- Do not copy private domains, Coolify IDs, credentials, logs, screenshots, or
+  deployment evidence into the fork.
+- Do not open upstream PRs with Turkiye community branding or private runtime
+  behavior.
+- Do not merge upstream `master` into a feature branch without checking whether
+  the change is Cloud-only, self-hosted, or deployment-specific.
+
+## Documentation Update Rule
+
+Whenever upstream changes are reviewed or imported:
+
+1. Update `UPSTREAM-CONTRIBUTIONS.md` if an upstream PR/issue is planned.
+2. Update `CHANGELOG.md` and `versions.md` when image tags or self-hosted
+   release baselines change.
+3. Update `PLATFORM-CAPABILITIES*.md` when the supported/self-hosted boundary
+   changes.
+4. Link the public summary from `DISCUSSIONS.md` using a bilingual Development
+   Log or Announcement post.
+

--- a/llms.txt
+++ b/llms.txt
@@ -18,6 +18,9 @@ Official status: Independent community project; not operated, supported, sponsor
 - [Platform capabilities](https://github.com/akin-umit/supabase-turkiye-community/blob/main/PLATFORM-CAPABILITIES.md): Cloud/self-hosted farkları ve doğrulanmış yetenekler
 - [Sık sorulan sorular](https://github.com/akin-umit/supabase-turkiye-community/blob/main/docs/FAQ.md): Kısa ve kaynak bağlantılı cevaplar
 - [AI/operator handoff](https://github.com/akin-umit/supabase-turkiye-community/blob/main/AI-HANDOFF.md): Geliştirici ve AI ajanları için güvenli çalışma sözleşmesi
+- [Community publication flow](https://github.com/akin-umit/supabase-turkiye-community/blob/main/COMMUNITY-PUBLICATION-FLOW.md): Private testten public community yayınına geçiş kuralı
+- [GitHub Discussions plan](https://github.com/akin-umit/supabase-turkiye-community/blob/main/DISCUSSIONS.md): Türkçe/İngilizce duyuru, geliştirme günlüğü ve forum bağlantı şablonları
+- [Upstream fork sync](https://github.com/akin-umit/supabase-turkiye-community/blob/main/UPSTREAM-FORK-SYNC.md): `akin-umit/supabase` forkunu resmi upstream ile güvenli güncelleme kuralı
 
 ## Important facts
 


### PR DESCRIPTION
## TR

Community tarafında kalıcı yayın ve planlama kuralı eklendi:

- Private test -> public community yayın akışı
- GitHub Discussions için Türkçe/İngilizce kategori ve post şablonları
- AI/yeni PC handoff kuralı: kalıcı hafıza repo dokümanlarında tutulur
- `akin-umit/supabase` fork sync politikası: upstream fetch-only, kör merge/reset yok
- README, roadmap, capabilities, contributing, agents ve changelog bağlantıları

## EN

Adds the permanent community publication and planning workflow:

- Private validation -> public community release flow
- Bilingual GitHub Discussions categories and post templates
- AI/new-machine handoff rule: durable memory lives in repository docs
- `akin-umit/supabase` fork sync policy: fetch-only upstream, no blind merge/reset
- README, roadmap, capabilities, contributing, agents and changelog links

## Checks

- `git diff --check`
- Local Markdown link check: 43 docs files
- Diff secret/private identifier scan: no new matches

No private domain, credential, Coolify ID, deployment ID or real secret was added.