### PR TITLE
🔗 Supabase Türkiye: Discussion bağlantılarını bağla

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -4,6 +4,8 @@ Supabase Türkiye Community'nin teknik içeriği için ana ve canonical kaynak b
 
 - **Canonical repository:** https://github.com/akin-umit/supabase-turkiye-community
 - **Repository Discussions:** https://github.com/akin-umit/supabase-turkiye-community/discussions
+- **Gelistirme Gunlugu / Development Log:** https://github.com/akin-umit/supabase-turkiye-community/discussions/18
+- **Yol Haritasi ve Katki Plani / Roadmap and Contribution Plan:** https://github.com/akin-umit/supabase-turkiye-community/discussions/19
 - **Issue tracker:** https://github.com/akin-umit/supabase-turkiye-community/issues
 
 Aşağıdaki sayfalar proje duyurularını, topluluk geri bildirimlerini ve herkese açık tartışmaları içerir. Bu bağlantılar bağımsız topluluk paylaşımlarıdır; Supabase tarafından resmî onay, destek, sponsorluk veya ortaklık anlamına gelmez.
@@ -24,3 +26,7 @@ Tanıtım konusu Supabase'in herkese açık GitHub Discussions alanında paylaş
 Bir forum gönderisi ile repository belgesi arasında farklılık varsa repository'nin `main` dalındaki güncel belge esas alınır. Forum sayfaları duyuru ve geri bildirim kanalıdır; kurulum komutu, güvenlik kararı, migration adımı veya platform yeteneği için canonical teknik kaynak değildir.
 
 Bu dizin son olarak **12 Temmuz 2026** tarihinde gözden geçirilmiştir.
+
+GitHub Discussions kategori adlari GitHub ayarlarindan yonetilir. Repository
+icindeki canonical baslik ve yayin kurallari icin [DISCUSSIONS.md](./DISCUSSIONS.md)
+esas alinir.

--- a/DISCUSSIONS.md
+++ b/DISCUSSIONS.md
@@ -27,6 +27,19 @@ GitHub Discussions yalniz Ingilizce kategori basliklariyla kullanilacaksa Turkce
 etiket aciklamaya yazilir. Turkce baslik kullanilacaksa Ingilizce etiket
 aciklamaya yazilir.
 
+## Live Discussion Threads / Canli Tartisma Basliklari
+
+These are the first canonical public threads. Use them instead of scattering
+updates across unrelated channels.
+
+Ilk canonical public basliklar bunlardir. Guncellemeleri daginik kanallara
+yazmak yerine bu basliklara baglayin.
+
+| Thread | Purpose |
+|---|---|
+| [Gelistirme Gunlugu / Development Log](https://github.com/akin-umit/supabase-turkiye-community/discussions/18) | Short bilingual summaries of completed work, validation status, and links to changelog/roadmap/PRs. |
+| [Yol Haritasi ve Katki Plani / Roadmap and Contribution Plan](https://github.com/akin-umit/supabase-turkiye-community/discussions/19) | Public roadmap discussion, feature ideas, contribution planning, and upstream-candidate coordination. |
+
 ## What Goes Into Discussions / Discussions'a Ne Yazilir?
 
 Every public update should be short and linked:
@@ -154,4 +167,3 @@ Yayinlanmayacaklar:
 - [Platform capabilities](./PLATFORM-CAPABILITIES.md)
 - [Community publication flow](./COMMUNITY-PUBLICATION-FLOW.md)
 - [Documentation maintenance contract](./DOCUMENTATION-MAINTENANCE.md)
-

--- a/README.en.md
+++ b/README.en.md
@@ -132,6 +132,12 @@ Generate fresh keys, use HTTPS, expose only the intended gateway, restrict datab
 6. Prepare a minimal branch in our [Supabase fork](https://github.com/akin-umit/supabase).
 7. Submit upstream only after following the target repository's contribution rules.
 
+## Community Discussions
+
+- [Gelistirme Gunlugu / Development Log](https://github.com/akin-umit/supabase-turkiye-community/discussions/18)
+- [Yol Haritasi ve Katki Plani / Roadmap and Contribution Plan](https://github.com/akin-umit/supabase-turkiye-community/discussions/19)
+- [Discussion plan and templates](./DISCUSSIONS.md)
+
 See [GOVERNANCE.md](./GOVERNANCE.md) and [UPSTREAM-CONTRIBUTIONS.md](./UPSTREAM-CONTRIBUTIONS.md).
 
 ## License, Attribution, and Trademark

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Yönetim kuralları: [GOVERNANCE.md](./GOVERNANCE.md) · [UPSTREAM-CONTRIBUTIONS
 
 Proje duyuruları, herkese açık geri bildirimler ve topluluk tartışmaları için:
 
+- [Gelistirme Gunlugu / Development Log](https://github.com/akin-umit/supabase-turkiye-community/discussions/18)
+- [Yol Haritasi ve Katki Plani / Roadmap and Contribution Plan](https://github.com/akin-umit/supabase-turkiye-community/discussions/19)
 - [Supabase Community — GitHub Discussions](https://github.com/orgs/supabase/discussions/47844)
 - [R10 tanıtım konusu](https://www.r10.net/proje-gelistirme-beyin-firtinasi-ortak-ariyorum/4824196-supabase-turkiye-community-turkce-self-hosted-coolify-ve-docker-kaynak-projesi.html)
 - [Technopat Sosyal tanıtım konusu](https://www.technopat.net/sosyal/konu/supabase-turkiye-community-turkce-self-hosted-coolify-ve-docker-kaynak-projesi.4140557/)

--- a/llms.txt
+++ b/llms.txt
@@ -39,6 +39,8 @@ Canonical technical source:
 
 Project-owned community index:
 - https://github.com/akin-umit/supabase-turkiye-community/blob/main/COMMUNITY.md
+- Development log / Gelistirme Gunlugu: https://github.com/akin-umit/supabase-turkiye-community/discussions/18
+- Roadmap and contribution plan / Yol Haritasi ve Katki Plani: https://github.com/akin-umit/supabase-turkiye-community/discussions/19
 
 Supabase Community:
 - https://github.com/orgs/supabase/discussions/47844


### PR DESCRIPTION
## Turkce

Public community alaninda olusturulan canli GitHub Discussions basliklarini canonical dokumanlara baglar.

- Gelistirme Gunlugu / Development Log: #18
- Yol Haritasi ve Katki Plani / Roadmap and Contribution Plan: #19
- README, README.en, COMMUNITY, DISCUSSIONS ve llms indeksleri guncellendi
- GitHub Discussions kategori adlarinin GitHub ayarlarindan yonetildigi not edildi

Dogrulama:
- git diff --check
- local markdown links OK
- GitHub GraphQL ile discussion #18 ve #19 varligi dogrulandi
- diff secret scan: hassas domain/secret eslesmesi yok

## English

Links the live GitHub Discussions threads into the canonical public community documents.

- Development Log / Gelistirme Gunlugu: #18
- Roadmap and Contribution Plan / Yol Haritasi ve Katki Plani: #19
- Updated README, README.en, COMMUNITY, DISCUSSIONS, and llms indexes
- Documented that GitHub Discussions category names are managed from GitHub settings

Validation:
- git diff --check
- local markdown links OK
- verified discussion #18 and #19 via GitHub GraphQL
- diff secret scan: no sensitive domain/secret matches