### PR TITLE
📚 Supabase Türkiye: Dashboard parity planını netleştir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Dashboard parity audit documentation - 2026-07-14
+
+- Added public-safe notes from the dashboard interaction audit.
+- Clarified that route rendering is not dashboard parity; hover states,
+  dropdowns, filters, nested tabs, empty/error states and scroll coverage still
+  need verification.
+- Added the preserve-first regression rule for new Studio packages: Function
+  Secrets, API Keys, JWT/JWKS, Operations, Usage, Observability Lite and
+  Dashboard Preferences must not disappear.
+- Clarified which settings can be self-host-active and which require a separate
+  operator backend or control plane.
+- Kept backup and migration cards as evidence-only until a job runner with
+  authorization, idempotency, audit logging and rollback exists.
+
+Related documents:
+
+- [Dashboard roadmap](./DASHBOARD-ROADMAP.md#2026-07-14-etkilesim-denetimi)
+- [Dashboard roadmap English](./DASHBOARD-ROADMAP.en.md#2026-07-14-interaction-audit)
+- [Platform capabilities](./PLATFORM-CAPABILITIES.md#dashboard-ayarlarini-aktif-gosterme-kurali)
+- [Platform capabilities English](./PLATFORM-CAPABILITIES.en.md#rule-for-showing-dashboard-settings-as-active)
+- [GitHub Discussions plan](./DISCUSSIONS.md)
+
 ## Community planning and publication rules - 2026-07-14
 
 - Added a permanent private-test to public-community publication flow.

--- a/DASHBOARD-ROADMAP.en.md
+++ b/DASHBOARD-ROADMAP.en.md
@@ -75,6 +75,12 @@ changelog links, and the required forum/Discussion note are prepared. Rule:
 - Remaining: backup/restore job execution, migration execution, and a separate
   multi-project control plane.
 
+Every new Studio package must preserve the accepted self-host surfaces first:
+Function Secrets, API Keys, JWT/JWKS, Operations, Usage, Observability Lite,
+Dashboard Preferences, Connect, status hover, and the copy menu. If one of
+those surfaces disappears, the package is not accepted as a release until the
+regression is fixed.
+
 ## Not Accepted or Easy to Misread
 
 - If the public route returns `503`, dashboard or API-key smoke is not accepted.
@@ -84,6 +90,9 @@ changelog links, and the required forum/Discussion note are prepared. Rule:
   backend exists for it.
 - Backup and migration cards currently show operator evidence only; the panel
   does not yet create backups, run restores, or apply migrations.
+- Rendering a route is not dashboard parity. Hover states, dropdowns, filters,
+  sort controls, create buttons, nested tabs, empty/error states, and scroll
+  coverage on long pages must be checked before a page is marked complete.
 
 ## Operator Summary
 
@@ -112,6 +121,29 @@ Two lessons from the Coolify/Kong work are now part of the public guidance:
 This note is generic community guidance. In production, the final answer still
 comes from container health, deployed commit, Compose config, and read-only
 smoke evidence.
+
+## 2026-07-14 Interaction Audit
+
+The official Supabase dashboard behavior adds these self-host planning
+boundaries:
+
+- The next Project Home package is not broad route cloning. It is compact
+  status, copy menu, self-host operations cards, usage cards, and
+  backup/migration evidence cards.
+- Observability and Logs are not only page lists. They include time-range
+  selectors, filters, metric cards, empty/error states, and Logflare/Vector
+  source status.
+- For Integrations, Data API, Vault, Cron, and Database Webhooks can be shown as
+  self-host surfaces when the required extension or service state exists.
+  Cloud-only wrappers and integrations are active only when an open-source
+  equivalent is deployed and verified.
+- For Settings, API Keys, JWT/JWKS, Auth/SMTP, Storage, and Realtime can be
+  active when backed by current config. Managed compute, PITR, billing,
+  subscription, Cloud Log Drains, and hosted AI Assistant remain disabled or
+  planned unless a separate operator backend exists.
+
+The delivery order remains: read-only self-host evidence first, controlled panel
+operations second, and a separate multi-project control plane last.
 
 ## Community Planning and Discussion Posts
 

--- a/DASHBOARD-ROADMAP.md
+++ b/DASHBOARD-ROADMAP.md
@@ -73,6 +73,11 @@ gerekli forum/discussion notu hazirlandiktan sonra yayinlanir. Kural:
 - Kalan: backup/restore job calistirma, migration uygulama ve ayri coklu proje
   control plane.
 
+Yeni Studio paketlerinde once korunacak yuzeyler: Function Secrets, API Keys,
+JWT/JWKS, Operations, Usage, Observability Lite, Dashboard Preferences, Connect,
+status hover ve copy menu. Bu yuzeylerden biri kaybolursa yeni paket release
+kabul edilmez; once regresyon giderilir.
+
 ## Kabul Edilmeyen veya Karistirilmamasi Gerekenler
 
 - Public route `503` donduruyorsa dashboard veya API key testi basarili
@@ -83,6 +88,9 @@ gerekli forum/discussion notu hazirlandiktan sonra yayinlanir. Kural:
   backendinin hazir oldugu anlamina gelmez.
 - Backup ve migration kartlari su an operator kaniti gosterir; panel henuz
   backup olusturmaz, restore calistirmaz veya migration uygulamaz.
+- Bir route'un acilmasi dashboard parity sayilmaz. Hover, dropdown, filtre,
+  siralama, create butonlari, nested tablar, hata/bos durumlari ve uzun
+  sayfalarda scroll kapsami kontrol edilmeden sayfa tamamlandi denmez.
 
 ## Operator Icin Kisa Durum
 
@@ -135,6 +143,28 @@ Coolify/Kong calismalarinda iki onemli ders netlesti:
 Bu not, public community icin geneldir. Her production ortaminda son karar
 container health, deploy commit, Compose config ve read-only smoke kanitiyla
 verilir.
+
+## 2026-07-14 Etkilesim Denetimi
+
+Resmi Supabase dashboard davranislari self-host planina su ilave ayrimlari
+getirdi:
+
+- Project Home icin siradaki paket, genis route kopyalama degil; compact
+  status, copy menu, self-host operasyon kartlari, usage kartlari ve
+  backup/migration kanit kartlaridir.
+- Observability ve Logs, yalniz sayfa listesi degil; zaman araligi secicileri,
+  filtreler, metrik kartlari, bos/hata durumlari ve Logflare/Vector kaynak
+  durumlariyla birlikte degerlendirilir.
+- Integrations icin Data API, Vault, Cron ve Database Webhooks self-hostta
+  extension/servis durumuyla gosterilebilir. Cloud-only wrapper ve entegrasyonlar
+  ancak acik kaynak karsiligi kuruldugunda aktif sayilir.
+- Settings icin API Keys, JWT/JWKS, Auth/SMTP, Storage ve Realtime gibi
+  config-backed ayarlar aktif olabilir. Managed compute, PITR, billing,
+  subscription, Cloud Log Drains ve hosted AI Assistant ise ayri operator
+  backend olmadan aktif gosterilmez.
+
+Siradaki uygulama sirasi: once read-only self-host kanit, sonra kontrollu panel
+operasyonlari, en son ayri coklu proje control plane.
 
 ## Community Planlama ve Forum Yayini
 

--- a/DISCUSSIONS.md
+++ b/DISCUSSIONS.md
@@ -27,6 +27,33 @@ GitHub Discussions yalniz Ingilizce kategori basliklariyla kullanilacaksa Turkce
 etiket aciklamaya yazilir. Turkce baslik kullanilacaksa Ingilizce etiket
 aciklamaya yazilir.
 
+## GitHub Settings Mapping / GitHub Ayar Eslemesi
+
+GitHub discussion categories are repository settings, not repository files.
+They must be updated from `Discussions > edit categories` by a repository admin.
+If the API later exposes category mutations, this table remains the canonical
+mapping for automation.
+
+GitHub discussion kategorileri repository ayaridir, dosya degildir. Repository
+admini tarafindan `Discussions > edit categories` ekranindan guncellenmelidir.
+API ileride kategori mutasyonlari acarsa otomasyon icin canonical esleme bu
+tablodur.
+
+| Current GitHub category | Target display name | Description |
+|---|---|---|
+| Announcements | Duyurular / Announcements | Maintainer duyurulari, surum ozetleri ve guvenli public durum guncellemeleri. |
+| General | Genel / General | Genel topluluk sohbeti; teknik karar gerektiren konular issue veya roadmap basligina tasinir. |
+| Ideas | Yol Haritasi ve Fikirler / Roadmap and Ideas | Planlanan isler, oncelikler, dashboard fazlari ve yeni ozellik fikirleri. |
+| Q&A | Yardim ve Soru-Cevap / Help and Q&A | Kurulum, Coolify, Docker, 503, API key, Storage/Auth hata cozumleri. |
+| Show and tell | Kurulum Paylasimlari / Show and Tell | Kullanicilarin gizli veri icermeyen kurulum deneyimleri ve demolar. |
+| Polls | Anketler / Polls | Topluluk oylamalari ve oncelik yoklamalari. |
+
+Optional extra category if GitHub allows adding it:
+
+| New category | Display name | Description |
+|---|---|---|
+| Development Log | Gelistirme Gunlugu / Development Log | Yapilan islerin kisa, surekli guncellenen, PR/changelog baglantili ozeti. |
+
 ## Live Discussion Threads / Canli Tartisma Basliklari
 
 These are the first canonical public threads. Use them instead of scattering

--- a/PLATFORM-CAPABILITIES.en.md
+++ b/PLATFORM-CAPABILITIES.en.md
@@ -63,6 +63,22 @@ for Auth, Storage, or Realtime.
 
 These are not described as planned unless an accepted and linked Issue or roadmap item exists.
 
+## Rule for Showing Dashboard Settings as Active
+
+A Supabase Cloud setting is not active in self-host just because the screen is
+visible. Every setting is classified before the UI presents it as working:
+
+| Setting family | Public status |
+|---|---|
+| API keys, JWT/JWKS, Auth providers, SMTP, Storage limits, Realtime settings | Can be active when current config and service state can be read safely. |
+| Data API, Vault, Cron, Database Webhooks | Can be active or setup-required when the required service or PostgreSQL extension exists. |
+| Logs and Observability | Active only when Logflare/Vector and the query source are healthy; otherwise show setup or disabled state. |
+| Managed compute resize, disk autoscaling, PITR, billing, subscription, Cloud Log Drains, hosted AI Assistant | Not provided by a single Docker stack; keep disabled or planned unless a separate operator backend exists. |
+| Backup/restore, migration apply, function deploy/restart/log actions | No active button until a job runner provides RBAC, idempotency, audit logs, and rollback behavior. |
+
+The goal is not fake Cloud parity. Use a self-host-safe equivalent when it
+exists; otherwise explain the boundary.
+
 ## Runtime Verification Contract
 
 A capability is runtime-verified only when evidence records the commit SHA, selected overlays, Compose validation, stable container health/restarts, read-only endpoint smoke test, persistent-data visibility where relevant, and rollback path.
@@ -80,6 +96,10 @@ Documentation update rules: [DOCUMENTATION-MAINTENANCE.md](./DOCUMENTATION-MAINT
 | Observability Lite | Query Performance only; cloud control-plane reports remain disabled. |
 | Dashboard Preferences | Local browser preferences with no platform API or billing dependency. |
 | Function Secrets | Redacted CRUD, persistent named volume, and Edge Runtime hot reload. |
+
+New Studio packages are not accepted as public releases unless these surfaces
+are preserved. Function Secrets, API Keys, JWT/JWKS, Operations, Usage,
+Observability Lite, and Dashboard Preferences are mandatory regression checks.
 
 Backup and migration cards display only operator-published status evidence. The
 dashboard does not yet create backups, execute restores, or apply migrations.

--- a/PLATFORM-CAPABILITIES.md
+++ b/PLATFORM-CAPABILITIES.md
@@ -77,6 +77,22 @@ degildir.
 
 Bu özellikler “yakında gelecek” olarak kabul edilmez. Yalnız onaylanmış ve bağlantılı bir Issue/roadmap varsa **Planlanıyor** olarak eklenebilir.
 
+## Dashboard Ayarlarini Aktif Gosterme Kurali
+
+Bir Supabase Cloud ayari self-host panelde yalniz gorunuyor diye aktif
+sayilmaz. Her ayar once asagidaki siniflardan birine girer:
+
+| Ayar grubu | Public durum |
+|---|---|
+| API keys, JWT/JWKS, Auth providers, SMTP, Storage limitleri, Realtime ayarlari | Config ve servis durumu okunabiliyorsa aktif gosterilebilir. |
+| Data API, Vault, Cron, Database Webhooks | Gerekli servis veya PostgreSQL extension mevcutsa aktif veya kurulum gerekli olarak gosterilebilir. |
+| Logs ve Observability | Logflare/Vector etkin ve sorgu kaynagi saglikliyse aktif; degilse kurulum/disabled durumu gosterilir. |
+| Managed compute resize, disk autoscaling, PITR, billing, subscription, Cloud Log Drains, hosted AI Assistant | Tek Docker stack icinde sunulmaz; ayri operator backend yoksa disabled/planned kalir. |
+| Backup/restore, migration apply, function deploy/restart/log actions | RBAC, idempotency, audit log ve rollback olan job runner olmadan aktif buton olmaz. |
+
+Bu kuralin amaci Cloud gorunumunu taklit ederken kullaniciyi yaniltmamaktir:
+self-host-safe equivalent varsa aktif edilir; yoksa sinir acik yazilir.
+
 ## Extension, Integration ve Client Ayrımı
 
 1. **PostgreSQL extension:** Image içinde mevcutsa SQL veya Studio üzerinden etkinleştirilebilir. Image içinde olmayan extension için özel image ve migration testi gerekir.
@@ -109,6 +125,10 @@ Bu kanıtlar yoksa belge yalnız **dahil**, **opsiyonel** veya **doğrulanmadı*
 | Observability Lite | Yalnız Query Performance; Cloud control-plane raporları kapalı kalır. |
 | Dashboard Preferences | Tarayıcıya yerel tercihler; Platform API veya billing bağımlılığı yoktur. |
 | Function Secrets | Redacted CRUD, kalıcı named volume ve Edge Runtime hot reload. |
+
+Yeni Studio paketleri bu yuzeyleri korumadan public release kabul edilmez.
+Function Secrets, API Keys, JWT/JWKS, Operations, Usage, Observability Lite ve
+Dashboard Preferences regresyon kontrol listesinin zorunlu parcasidir.
 
 Backup ve migration kartları yalnız operatörün yayınladığı durum kanıtını
 gösterir. Panel henüz backup oluşturmaz, restore çalıştırmaz veya migration


### PR DESCRIPTION
## TR

### Kisa ozet

Bu PR, self-host dashboard parity calismasinin public planini netlestirir. Resmi Supabase dashboard davranislarindan cikan genel dersleri public-safe sekilde roadmap, capability tablosu ve changelog'a ekler.

### Kapsam

- Dashboard route render etmenin parity sayilmadigi netlestirildi.
- Hover, dropdown, filtre, nested tab, bos/hata durumu ve scroll kapsami kural olarak eklendi.
- Yeni Studio paketlerinde Function Secrets, API Keys, JWT/JWKS, Operations, Usage, Observability Lite ve Dashboard Preferences yuzeylerinin korunmasi zorunlu hale getirildi.
- Self-hostta aktif gosterilebilecek ayarlar ile Cloud-only/operator-backend gerektiren ayarlar ayrildi.
- Backup/migration kartlarinin evidence-only oldugu tekrar netlestirildi.

### Guvenlik

Private domain, commit, image tag, workflow URL, screenshot, log, credential veya runtime evidence eklenmedi.

### Kontroller

- git diff --check
- secret pattern scan

## EN

### Short summary

This PR clarifies the public plan for self-host dashboard parity. It adds public-safe lessons from the official dashboard interaction audit to the roadmap, capability table, and changelog.

### Scope

- Clarifies that route rendering is not dashboard parity.
- Adds hover, dropdown, filter, nested tab, empty/error state, and scroll coverage as acceptance requirements.
- Requires new Studio packages to preserve Function Secrets, API Keys, JWT/JWKS, Operations, Usage, Observability Lite, and Dashboard Preferences.
- Separates settings that can be active in self-host from Cloud-only or operator-backend features.
- Keeps backup/migration cards evidence-only.

### Security

No private domains, commits, image tags, workflow URLs, screenshots, logs, credentials, or runtime evidence are included.

### Checks

- git diff --check
- secret pattern scan